### PR TITLE
Fixing "quantize result has too many digits for current context" issue

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -231,7 +231,7 @@ class FloatObject(decimal.Decimal, PdfObject):
 
     def __repr__(self):
         if self == self.to_integral():
-            return str(self.quantize(decimal.Decimal(1)))
+            return str(self.quantize(decimal.Decimal(1), context=decimal.ExtendedContext))
         else:
             # XXX: this adds useless extraneous zeros.
             return "%.5f" % self


### PR DESCRIPTION
I have experienced another issue with some kind of PDFs. This Pull Request solves this issue:
- Quantize result has too many digits for current context.

The solution I found was to use an ExtendedContext.
