### PR TITLE
PI: Check duplicate objects in writer._sweep_indirect_references

### DIFF
--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -869,13 +869,16 @@ class PdfWriter:
                 if newobj is None:
                     try:
                         newobj = data.pdf.get_object(data)
-                        hash_value = newobj.hash_value()
+                        hash_value = None
+                        if newobj is not None:
+                            hash_value = newobj.hash_value()
                         # Check if object is already added to pdf.
                         if hash_value in self._idnum_hash:
                             return IndirectObject(self._idnum_hash[hash_value], 0, self)
                         self._objects.append(None)  # placeholder
                         idnum = len(self._objects)
-                        self._idnum_hash[hash_value] = idnum
+                        if hash_value is not None:
+                            self._idnum_hash[hash_value] = idnum
                         newobj_ido = IndirectObject(idnum, 0, self)
                         if data.pdf not in extern_map:
                             extern_map[data.pdf] = {}

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -92,6 +92,7 @@ class PdfWriter:
     def __init__(self) -> None:
         self._header = b"%PDF-1.3"
         self._objects: List[Optional[PdfObject]] = []  # array of indirect objects
+        self._idnum_hash: Dict[bytes, int] = {}
 
         # The root of our page tree node.
         pages = DictionaryObject()
@@ -868,8 +869,13 @@ class PdfWriter:
                 if newobj is None:
                     try:
                         newobj = data.pdf.get_object(data)
+                        hash_value = newobj.hash_value()
+                        # Check if object is already added to pdf.
+                        if hash_value in self._idnum_hash:
+                            return IndirectObject(self._idnum_hash[hash_value], 0, self)
                         self._objects.append(None)  # placeholder
                         idnum = len(self._objects)
+                        self._idnum_hash[hash_value] = idnum
                         newobj_ido = IndirectObject(idnum, 0, self)
                         if data.pdf not in extern_map:
                             extern_map[data.pdf] = {}


### PR DESCRIPTION
PdfFileWriter._sweepIndirectReferences checks if object is already in pdf.

This check will reduce file-size significantly when merge pdfs and there are same objects, for example images.
