### PR TITLE
Warning should not trigger when strict is false

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -580,7 +580,6 @@ class DictionaryObject(dict, PdfObject):
                 # multiple definitions of key not permitted
                 raise utils.PdfReadError("Multiple definitions in dictionary at byte %s for key %s" \
                                            % (utils.hexStr(stream.tell()), key))
-            else:
                 warnings.warn("Multiple definitions in dictionary at byte %s for key %s" \
                                            % (utils.hexStr(stream.tell()), key), utils.PdfReadWarning)
 


### PR DESCRIPTION
It should behave similar to other places such as https://github.com/sebslomski/PyPDF2/blob/57b3fe8100474a189f703af9629394de67511ee8/PyPDF2/generic.py#L486
