### PR TITLE
Discrete Text Extraction

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2587,15 +2587,27 @@ class PageObject(DictionaryObject):
     def extractText(self):
         """
         Locate all text drawing commands, in the order they are provided in the
-        content stream, and extract the text.  This works well for some PDF
+        content stream, extract the text from each, and concatenate into a single
+        string.
+
+        :return: a unicode string object.
+        """
+
+        return u_('').join(self.extractTextList())
+
+    def extractTextList(self):
+        """
+        Locate all text drawing commands, in the order they are provided in the
+        content stream, and extract the text from each.  This works well for some PDF
         files, but poorly for others, depending on the generator used.  This will
         be refined in the future.  Do not rely on the order of text coming out of
         this function, as it will change if this function is made more
         sophisticated.
 
-        :return: a unicode string object.
+        :return: a list of unicode string objects
         """
-        text = u_("")
+
+        text_list = [u_("")]
         content = self["/Contents"].getObject()
         if not isinstance(content, ContentStream):
             content = ContentStream(content, self.pdf)
@@ -2606,25 +2618,26 @@ class PageObject(DictionaryObject):
             if operator == b_("Tj"):
                 _text = operands[0]
                 if isinstance(_text, TextStringObject):
-                    text += _text
+                    text_list.append(_text)
             elif operator == b_("T*"):
-                text += "\n"
+                text_list.append(u_("\n"))
             elif operator == b_("'"):
-                text += "\n"
+                text_list.append(u_("\n"))
                 _text = operands[0]
                 if isinstance(_text, TextStringObject):
-                    text += operands[0]
+                    text_list.append(operands[0])
             elif operator == b_('"'):
                 _text = operands[2]
                 if isinstance(_text, TextStringObject):
-                    text += "\n"
-                    text += _text
+                    text_list.append(u_("\n"))
+                    text_list.append(_text)
             elif operator == b_("TJ"):
                 for i in operands[0]:
                     if isinstance(i, TextStringObject):
-                        text += i
-                text += "\n"
-        return text
+                        text_list.append(i)
+                text_list.append(u_("\n"))
+
+        return text_list
 
     mediaBox = createRectangleAccessor("/MediaBox", ())
     """


### PR DESCRIPTION
The method `PageObject.extractText` concatenates all text commands in whatever order they appear. While this can be useful, some information is lost.

This PR adds a new method, `PageObject.extractTextList`, which returns a list of text commands instead of concatenating to a single unicode string.
