### PR TITLE
Improved performance and security for ContentStream_readInlineImage

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2787,11 +2787,27 @@ class ContentStream(DecodedStreamObject):
         # left at beginning of ID
         tmp = stream.read(3)
         assert tmp[:2] == b_("ID")
-        data = b_("")
+        data = BytesIO()
+        # Read the inline image, while checking for EI (End Image) operator.
         while True:
-            # Read the inline image, while checking for EI (End Image) operator.
-            tok = stream.read(1)
-            if tok == b_("E"):
+            # Read 8 kB at a time and check if the chunk contains the E operator.
+            buf = stream.read(8192)
+            
+            # We have reached the end of the stream, but haven't found the EI operator.
+            if not buf:
+                raise utils.PdfReadError("Unexpected end of stream")
+            
+            loc = buf.find(b_("E"))
+
+            if loc == -1:
+                data.write(buf)
+            else:
+                # Write out everything before the E.
+                data.write(buf[0:loc])
+
+                # Seek back in the stream to read the E next.
+                stream.seek(loc - len(buf), 1)
+                tok = stream.read(1)
                 # Check for End Image
                 tok2 = stream.read(1)
                 if tok2 == b_("I"):
@@ -2808,14 +2824,12 @@ class ContentStream(DecodedStreamObject):
                         stream.seek(-1, 1)
                         break
                     else:
-                        stream.seek(-1,1)
-                        data += info
+                        stream.seek(-1, 1)
+                        data.write(info)
                 else:
                     stream.seek(-1, 1)
-                    data += tok
-            else:
-                data += tok
-        return {"settings": settings, "data": data}
+                    data.write(tok)
+        return {"settings": settings, "data": data.getvalue()}
 
     def _getData(self):
         newdata = BytesIO()


### PR DESCRIPTION
This change has been tested with Python 2.6, 2.7 and 3.5.

It fixes #329 by raising an exception when the stream ends and we haven't the end token for the inline image.

It also fixes #330 by using a more efficient parsing algorithm. For large inline images this change speeds up this method by many orders of magnitude:

- Instead of only reading single bytes from the stream it reads larger chunks of 8 kB and uses Python's really fast `find()` method to check for the `E` the token. Only when the token is found it falls back to the normal algorithm that detects the end of the inline image.
- Instead of using an immutable `data` it uses `BytesIO` to collect the output which support much faster appends.