### PR TITLE
Install pdfcat with the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setup(
             "Topic :: Software Development :: Libraries :: Python Modules",
             ],
         packages=["PyPDF2"],
+        scripts=["Scripts/pdfcat"]
     )


### PR DESCRIPTION
Resolves #259.

Maybe it should be called `pypdf-cat` if there are competing tools with the same name.