### PR TITLE
Restrict print/copy/paste option

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -420,7 +420,7 @@ class PdfFileWriter(object):
             rev = 2
             keylen = int(40 / 8)
         # permit everything:
-        P = -1
+        P = -3904
         O = ByteStringObject(_alg33(owner_pwd, user_pwd, rev, keylen))
         ID_1 = ByteStringObject(md5(b_(repr(time.time()))).digest())
         ID_2 = ByteStringObject(md5(b_(repr(random.random()))).digest())


### PR DESCRIPTION
pdf password protected print copy paste options, makesure to pass in a different `owner_pwd`
https://stackoverflow.com/questions/13109867/python-pdf-set-password-protected-print-copy-paste-options#answer-36016018