### PR TITLE
readObjectHeader: Allow extra whitespace before "obj"

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -1734,6 +1734,7 @@ class PdfFileReader(object):
         idnum = readUntilWhitespace(stream)
         extra |= utils.skipOverWhitespace(stream); stream.seek(-1, 1)
         generation = readUntilWhitespace(stream)
+        extra |= utils.skipOverWhitespace(stream); stream.seek(-1, 1)
 
         # although it's not used, it might still be necessary to read
         _obj = stream.read(3)  # noqa: F841


### PR DESCRIPTION
The header being read by `readObjectHeader` has the format:

    <idnum> <generation> obj

where `<idnum>` and `<generation>` are integers.
Previously an arbitrary number of spaces was being allowed between `<idnum>` and `<generation>`, but not between `<generation>` and `obj`.

With this pull request an arbitrary number of spaces between `<generation>` and `obj` is allowed (but raises a warning similarly to how other extraneous whitespace is handled) .