### PR TITLE
Optimize read_next_end_line

### DIFF
--- a/PyPDF2/_utils.py
+++ b/PyPDF2/_utils.py
@@ -131,7 +131,9 @@ def read_until_regex(stream: StreamType, regex: Any, ignore_eof: bool = False) -
         name += tok
     return name
 
+
 CRLF = b'\r\n'
+
 
 def read_block_backwards(stream: StreamType, to_read: int) -> bytes:
     """Given a stream at position X, read a block of size
@@ -148,6 +150,7 @@ def read_block_backwards(stream: StreamType, to_read: int) -> bytes:
     if len(read) != to_read:
         raise PdfStreamError('EOF: read %s, expected %s?' % (len(read), to_read))
     return read
+
 
 def read_previous_line(stream: StreamType) -> bytes:
     """Given a byte stream with current position X, return the previous
@@ -196,6 +199,7 @@ def read_previous_line(stream: StreamType) -> bytes:
             break
     # Join all the blocks in the line (which are in reverse order)
     return b''.join(line_content[::-1])
+
 
 def matrix_multiply(
     a: TransformationMatrixType, b: TransformationMatrixType

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -10,7 +10,7 @@ from PyPDF2._reader import convert_to_int, convertToInt
 from PyPDF2.constants import ImageAttributes as IA
 from PyPDF2.constants import PageAttributes as PG
 from PyPDF2.constants import Ressources as RES
-from PyPDF2.errors import PdfReadError, PdfReadWarning
+from PyPDF2.errors import PdfReadError, PdfReadWarning, STREAM_TRUNCATED_PREMATURELY
 from PyPDF2.filters import _xobj_to_image
 from tests import get_pdf_from_url
 
@@ -400,7 +400,7 @@ def test_read_malformed_header():
 def test_read_malformed_body():
     with pytest.raises(PdfReadError) as exc:
         PdfReader(io.BytesIO(b"%PDF-"), strict=True)
-    assert exc.value.args[0] == "Could not read malformed PDF file"
+    assert exc.value.args[0] == STREAM_TRUNCATED_PREMATURELY
 
 
 def test_read_prev_0_trailer():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,10 +134,11 @@ def test_paeth_predictor(left, up, upleft, expected):
     ],
 )
 def test_read_block_backwards_errs(dat, pos, to_read):
-    with pytest.raises(PdfStreamError) as exc:
+    with pytest.raises(PdfStreamError) as _:
         s = io.BytesIO(dat)
         s.seek(pos)
         read_block_backwards(s, to_read)
+
 
 @pytest.mark.parametrize(
     ("dat", "pos", "to_read", "expected", "expected_pos"),
@@ -160,8 +161,9 @@ def test_read_block_backwards(dat, pos, to_read, expected, expected_pos):
 
 def test_read_block_backwards_at_start():
     s = io.BytesIO(b'abc')
-    with pytest.raises(PdfStreamError) as exc:
+    with pytest.raises(PdfStreamError) as _:
         read_previous_line(s)
+
 
 @pytest.mark.parametrize(
     ("dat", "pos", "expected", "expected_pos"),
@@ -181,7 +183,7 @@ def test_read_block_backwards_at_start():
         (b'abc\n' + b'd' * (2 * io.DEFAULT_BUFFER_SIZE), 2 * io.DEFAULT_BUFFER_SIZE + 4, b'd' * (2 * io.DEFAULT_BUFFER_SIZE), 3),
         # Both
         (b'abcxyz' + b'\n' * (2 * io.DEFAULT_BUFFER_SIZE) + b'd' * (2 * io.DEFAULT_BUFFER_SIZE),\
-                4 * io.DEFAULT_BUFFER_SIZE + 6, b'd' * (2 * io.DEFAULT_BUFFER_SIZE), 6),
+            4 * io.DEFAULT_BUFFER_SIZE + 6, b'd' * (2 * io.DEFAULT_BUFFER_SIZE), 6),
     ],
 )
 def test_read_previous_line(dat, pos, expected, expected_pos):


### PR DESCRIPTION
This function (which reads the previous line in a binary stream) is pretty inefficient when handling long lines - if the stream is a buffered binary stream, each one-byte "backwards" read may trigger a full buffer read, and (more significantly) iteratively building the line we want to return is quadratic in its total length.