### PR TITLE
Add blank page to merger

### DIFF
--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -549,7 +549,7 @@ class PdfFileMerger(object):
 
         # Create a blank page and add it to the merger (for the specified number of times)
         blank_file = PdfFileWriter()
-        blank_file.addBlankPage(width=width/coef, height=height/coef)
+        blank_file.addBlankPage(width=page_width/coef, page_height=height/coef)
         blank_file_memory = BytesIO()
         blank_file.write(blank_file_memory)
         for i in range(number_of_pages_to_add):    


### PR DESCRIPTION
Added a method to add a blank page to the merger
 Useful if you merge pdf with odd number of pages and you want to keep recto/verso

To use you have to make something like:
```python
merger.append("pdf1.pdf")
with open("pdf1.pdf", "rb") as pdf_file:
	page_number = PdfFileReader(pdf_file).getNumPages()
if page_number % 2 != 0:
	merger.addBlankPage()
```