### PR TITLE
in test_writer.py, make sure tmp file is closed before removing it

### DIFF
--- a/Tests/test_writer.py
+++ b/Tests/test_writer.py
@@ -74,8 +74,9 @@ def test_remove_images():
     with open(tmp_filename, "wb") as output_stream:
         output.write(output_stream)
 
-    reader = PdfFileReader(open(tmp_filename, "rb"))
-    assert "Lorem ipsum dolor sit amet" in reader.getPage(0).extractText()
+    with open(tmp_filename, "rb") as input_stream:
+        reader = PdfFileReader(input_stream)
+        assert "Lorem ipsum dolor sit amet" in reader.getPage(0).extractText()
 
     # Cleanup
     os.remove(tmp_filename)


### PR DESCRIPTION
Without this fix, running the test suite on Windows results in:

`FAILED Tests/test_writer.py::test_remove_images - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'dont_commit_writer_removed_image.pdf'`