### PR TITLE
BUG: Fix ASCII85Decode.decode assertion

### DIFF
--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -308,7 +308,7 @@ class ASCII85Decode(object):
                         group[2] * (85**2) + \
                         group[3] * 85 + \
                         group[4]
-                    assert b < (2**32 - 1)
+                    assert b <= (2**32 - 1)
                     c4 = chr((b >> 0) % 256)
                     c3 = chr((b >> 8) % 256)
                     c2 = chr((b >> 16) % 256)


### PR DESCRIPTION
BUG: Off-by-one
FIX: Set 2**32-1 inclusive

Closes #312

Credits to Michael Sander (speedplane) who
included it here:
https://github.com/py-pdf/PyPDF2/pull/333