### PR TITLE
DEP: Remove Python 2.6 and older support

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -76,13 +76,7 @@ from .utils import (
     u_,
 )
 
-if version_info < ( 2, 4 ):
-   from sets import ImmutableSet as frozenset
-
-if version_info < ( 2, 5 ):
-    from md5 import md5
-else:
-    from hashlib import md5
+from hashlib import md5
 
 
 class PdfFileWriter(object):


### PR DESCRIPTION
"New" features that we use:

* PEP-343: with statements (Python 2.5+)
* PEP-389: argparse (Python 2.7+; just in Scripts)
* https://bugs.python.org/issue2335 : Set literals
* https://bugs.python.org/issue2333 : Dictionary / set comprehensions
* ...

Python 2.6 had its last security update in 2013 - 9 years ago.
I'm sure people have long moved on.

The package is also marked as Python 2.7+ and CI only runs for
Python 2.7 and 3.6+.

For this reason, I will not make a major version bump.