### PR TITLE
Skip NameObject when building outline, fixes #193

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -1569,6 +1569,8 @@ class PdfFileReader(object):
             elif isString(dest) and dest in self._namedDests:
                 outline = self._namedDests[dest]
                 outline[NameObject("/Title")] = title
+            elif isinstance(dest, NameObject):
+                pass
             else:
                 raise PdfReadError("Unexpected destination %r" % dest)
         return outline


### PR DESCRIPTION
Fixes #193, uses @hannal's solution to resolve read/merge issues with wkhtmltopdf pdfs by skipping NameObject entities. 