### PR TITLE
ROB: Invalid float object; use 0 as fallback

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -36,6 +36,7 @@ import codecs
 import decimal
 import re
 import warnings
+import logging
 
 from PyPDF2.constants import FilterTypes as FT
 from PyPDF2.constants import StreamAttributes as SA
@@ -57,6 +58,7 @@ from .utils import (
     u_,
 )
 
+logger = logging.getLogger(__name__)
 ObjectPrefix = b_('/<[tf(n%')
 NumberSigns = b_('+-')
 IndirectPattern = re.compile(b_(r"[+-]?(\d+)\s+(\d+)\s+R[^a-zA-Z]"))
@@ -237,7 +239,14 @@ class FloatObject(decimal.Decimal, PdfObject):
         try:
             return decimal.Decimal.__new__(cls, utils.str_(value), context)
         except Exception:
-            return decimal.Decimal.__new__(cls, str(value))
+            try:
+                return decimal.Decimal.__new__(cls, str(value))
+            except decimal.InvalidOperation:
+                # If this isn't a valid decimal (happens in malformed PDFs)
+                # fallback to 0
+                #
+                logger.warning("Invalid FloatObject {}".format(value))
+                return decimal.Decimal.__new__(cls, "0")
 
     def __repr__(self):
         if self == self.to_integral():

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -244,7 +244,6 @@ class FloatObject(decimal.Decimal, PdfObject):
             except decimal.InvalidOperation:
                 # If this isn't a valid decimal (happens in malformed PDFs)
                 # fallback to 0
-                #
                 logger.warning("Invalid FloatObject {}".format(value))
                 return decimal.Decimal.__new__(cls, "0")
 


### PR DESCRIPTION
Users report the following error:
    decimal.InvalidOperation: [<class 'decimal.ConversionSyntax'>]
and:
    InvalidOperation: Invalid Literal for Decimal '0.0000-74251147'

Ghostscript when it encounters this reference, treats the value as if it
was "0.0". PyPDF2 will now do the same.

Closes #386

Co-authored-by: James Campbell <james@supmenow.com>