### PR TITLE
DEV: Ignore IronPython parts for code coverage

### DIFF
--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -70,7 +70,7 @@ try:
     def compress(data):
         return zlib.compress(data)
 
-except ImportError:
+except ImportError:  # pragma: no cover
     # Unable to import zlib.  Attempt to use the System.IO.Compression
     # library from the .NET framework. (IronPython only)
     import System


### PR DESCRIPTION
I have no idea how to test for that in GithubActions.
As this likely only affects a small fraction of PyPDF2 users,
I want to ignore it for now.

Feel free to add a PR that adds IronPython to GithubActions -
then we can enable this again.