### PR TITLE
MAINT: Separated CCITTFax param parsing/decoding

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -74,12 +74,10 @@ from PyPDF2.utils import (
 
 if version_info < (3, 0):
     from cStringIO import StringIO
-else:
-    from io import StringIO
-if version_info < (3, 0):
+
     BytesIO = StringIO
 else:
-    from io import BytesIO
+    from io import BytesIO, StringIO
 
 
 def convertToInt(d, size):
@@ -567,7 +565,7 @@ class PdfFileReader(object):
             self._pageId2Num = id2num
 
         if isinstance(indirectRef, NullObject):
-             return -1
+            return -1
         if isinstance(indirectRef, int):
             idnum = indirectRef
         else:
@@ -613,10 +611,10 @@ class PdfFileReader(object):
             if self.strict:
                 raise
             else:
-                #create a link to first Page
-                return Destination(title, self.getPage(0).indirectRef,
-                                   TextStringObject("/Fit"))
-
+                # create a link to first Page
+                return Destination(
+                    title, self.getPage(0).indirectRef, TextStringObject("/Fit")
+                )
 
     def _buildOutline(self, node):
         dest, title, outline = None, None, None

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -63,12 +63,10 @@ from .utils import (
 
 if version_info < (3, 0):
     from cStringIO import StringIO
-else:
-    from io import StringIO
-if version_info < (3, 0):
+
     BytesIO = StringIO
 else:
-    from io import BytesIO
+    from io import BytesIO, StringIO
 
 logger = logging.getLogger(__name__)
 ObjectPrefix = b_("/<[tf(n%")

--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -42,13 +42,10 @@ from sys import version_info
 
 if version_info < (3, 0):
     from cStringIO import StringIO
-else:
-    from io import StringIO
 
-if version_info < (3, 0):
     BytesIO = StringIO
 else:
-    from io import BytesIO  # noqa: F401
+    from io import StringIO, BytesIO  # noqa: F401
 
 import codecs  # noqa: F401
 import warnings  # noqa: F401

--- a/Tests/test_generic.py
+++ b/Tests/test_generic.py
@@ -19,6 +19,7 @@ from PyPDF2.generic import (
     NumberObject,
     PdfObject,
     RectangleObject,
+    TextStringObject,
     createStringObject,
     encode_pdfdocencoding,
     readHexStringFromStream,
@@ -327,3 +328,16 @@ def test_RectangleObject():
 
     ro.upperRight = (13, 17)
     assert ro.upperRight == (13, 17)
+
+
+def test_TextStringObject_exc():
+    tso = TextStringObject("foo")
+    with pytest.raises(Exception) as exc:
+        tso.get_original_bytes()
+    assert exc.value.args[0] == "no information about original bytes"
+
+
+def test_TextStringObject_autodetect_utf16():
+    tso = TextStringObject("foo")
+    tso.autodetect_utf16 = True
+    assert tso.get_original_bytes() == b"\xfe\xff\x00f\x00o\x00o"

--- a/Tests/test_reader.py
+++ b/Tests/test_reader.py
@@ -547,6 +547,7 @@ def test_reader_properties():
     assert reader.pageMode is None
     assert reader.isEncrypted is False
 
+
 @pytest.mark.parametrize(
     "strict",
     [(True), (False)],
@@ -564,14 +565,14 @@ def test_issue604(strict):
                 bookmarks = pdf.getOutlines()
             if "Unknown Destination" not in exc.value.args[0]:
                 raise Exception("Expected exception not raised")
-            return # bookmarks not correct
+            return  # bookmarks not correct
         else:
             pdf = PdfFileReader(f, strict=strict)
             bookmarks = pdf.getOutlines()
 
         def getDestPages(x):
             # print(x)
-            if isinstance(x,list):
+            if isinstance(x, list):
                 r = [getDestPages(y) for y in x]
                 return r
             else:
@@ -582,7 +583,8 @@ def test_issue604(strict):
             b
         ) in bookmarks:  # b can be destination or a list:preferred to just print them
             out.append(getDestPages(b))
-    #print(out)
+    # print(out)
+
 
 def test_decode_permissions():
     reader = PdfFileReader(os.path.join(RESOURCE_ROOT, "crazyones.pdf"))


### PR DESCRIPTION
* BUG: Changed default /K to conform with the PDF 1.7 standard
* TST: Add test for CCITTFax
* TST: Add test for TextStringObject

STY:
* Group Python 2.7 imports
* camelCase variables to snake_case
* Apply black formatter