### PR TITLE
DEP: overwriteWarnings parameter of reader/merger

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,10 @@ Version 2.0.0
 
 Deprecations (DEP):
 - PyPDF2 2.0 requires Python 3.6+. Python 2.7 and 3.5 support were dropped.
+- PdfFileReader and PdfFileMerger no longer have the `overwriteWarnings`
+  parameter. The new behavior is `overwriteWarnings=False`.
 - utils:
+  * `formatWarning` was removed
   * `isInt(obj)`: Use `instance(obj, int)` instead
   * `u_(s)`: Use `s` directly
   * `chr_(c)`: Use `chr(c)` instead

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -64,12 +64,7 @@ from PyPDF2.generic import (
     readNonWhitespace,
     readObject,
 )
-from PyPDF2.utils import (
-    ConvertFunctionsToVirtualList,
-    b_,
-    formatWarning,
-    readUntilWhitespace,
-)
+from PyPDF2.utils import ConvertFunctionsToVirtualList, b_, readUntilWhitespace
 
 
 def convertToInt(d, size):
@@ -188,32 +183,9 @@ class PdfFileReader(object):
         Defaults to ``True``.
     :param warndest: Destination for logging warnings (defaults to
         ``sys.stderr``).
-    :param bool overwriteWarnings: Determines whether to override Python's
-        ``warnings.py`` module with a custom implementation (defaults to
-        ``True``).
     """
 
-    def __init__(self, stream, strict=True, warndest=None, overwriteWarnings=True):
-        if overwriteWarnings:
-            # Have to dynamically override the default showwarning since there
-            # are no public methods that specify the 'file' parameter
-            def _showwarning(
-                message, category, filename, lineno, file=warndest, line=None
-            ):
-                if file is None:
-                    file = sys.stderr
-                try:
-                    # It is possible for sys.stderr to be defined as None, most commonly in the case that the script
-                    # is being run vida pythonw.exe on Windows. In this case, just swallow the warning.
-                    # See also https://docs.python.org/3/library/sys.html# sys.__stderr__
-                    if file is not None:
-                        file.write(
-                            formatWarning(message, category, filename, lineno, line)
-                        )
-                except IOError:
-                    pass
-
-            warnings.showwarning = _showwarning
+    def __init__(self, stream, strict=True, warndest=None):
         self.strict = strict
         self.flattenedPages = None
         self.resolvedObjects = {}

--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -63,12 +63,9 @@ class PdfFileMerger(object):
     :param bool strict: Determines whether user should be warned of all
             problems and also causes some correctable problems to be fatal.
             Defaults to ``True``.
-    :param bool overwriteWarnings: Determines whether to override Python's
-        ``warnings.py`` module with a custom implementation (defaults to
-        ``True``).
     """
 
-    def __init__(self, strict=True, overwriteWarnings=True):
+    def __init__(self, strict=True):
         self.inputs = []
         self.pages = []
         self.output = PdfFileWriter()
@@ -76,7 +73,6 @@ class PdfFileMerger(object):
         self.named_dests = []
         self.id_count = 0
         self.strict = strict
-        self.overwriteWarnings = overwriteWarnings
 
     def merge(
         self, position, fileobj, bookmark=None, pages=None, import_bookmarks=True
@@ -139,9 +135,7 @@ class PdfFileMerger(object):
 
         # Create a new PdfFileReader instance using the stream
         # (either file or BytesIO or StringIO) created above
-        pdfr = PdfFileReader(
-            fileobj, strict=self.strict, overwriteWarnings=self.overwriteWarnings
-        )
+        pdfr = PdfFileReader(fileobj, strict=self.strict)
         if decryption_key is not None:
             pdfr._decryption_key = decryption_key
 

--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -39,12 +39,6 @@ from PyPDF2.errors import STREAM_TRUNCATED_PREMATURELY, PdfStreamError
 bytes_type = type(bytes())  # Works the same in Python 2.X and 3.X
 
 
-def formatWarning(message, category, filename, lineno, line=None):
-    """custom implementation of warnings.formatwarning"""
-    file = filename.replace("/", "\\").rsplit("\\", 1)[-1]  # find the file name
-    return "%s: %s [%s:%s]\n" % (category.__name__, message, file, lineno)
-
-
 def readUntilWhitespace(stream, maxchars=None):
     """
     Reads non-whitespace characters and returns them.

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -353,7 +353,7 @@ def test_io_streams():
 
 def test_regression_issue670():
     filepath = os.path.join(RESOURCE_ROOT, "crazyones.pdf")
-    reader = PdfFileReader(filepath, strict=False, overwriteWarnings=False)
+    reader = PdfFileReader(filepath, strict=False)
     for _ in range(2):
         pdf_writer = PdfFileWriter()
         pdf_writer.addPage(reader.getPage(0))


### PR DESCRIPTION
PdfFileReader and PdfFileMerger no longer have the `overwriteWarnings`.
The new behavior is `overwriteWarnings=False`.

Additionally, PyPDF2.utils.formatWarning was removed