### PR TITLE
Change default to strict=False in PdfFileReader/PdfFileMerger

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -180,12 +180,12 @@ class PdfFileReader(object):
         string representing a path to a PDF file.
     :param bool strict: Determines whether user should be warned of all
         problems and also causes some correctable problems to be fatal.
-        Defaults to ``True``.
+        Defaults to ``False``.
     :param warndest: Destination for logging warnings (defaults to
         ``sys.stderr``).
     """
 
-    def __init__(self, stream, strict=True, warndest=None):
+    def __init__(self, stream, strict=False, warndest=None):
         self.strict = strict
         self.flattenedPages = None
         self.resolvedObjects = {}
@@ -1026,7 +1026,7 @@ class PdfFileReader(object):
                         PdfReadWarning,
                     )
                     # if table not zero indexed, could be due to error from when PDF was created
-                    # which will lead to mismatched indices later on, only warned and corrected if self.strict=True
+                    # which will lead to mismatched indices later on, only warned and corrected if self.strict==True
             firsttime = False
             readNonWhitespace(stream)
             stream.seek(-1, 1)

--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -62,10 +62,10 @@ class PdfFileMerger(object):
 
     :param bool strict: Determines whether user should be warned of all
             problems and also causes some correctable problems to be fatal.
-            Defaults to ``True``.
+            Defaults to ``False``.
     """
 
-    def __init__(self, strict=True):
+    def __init__(self, strict=False):
         self.inputs = []
         self.pages = []
         self.output = PdfFileWriter()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -363,13 +363,13 @@ def test_read_empty():
 
 def test_read_malformed_header():
     with pytest.raises(PdfReadError) as exc:
-        PdfFileReader(io.BytesIO(b"foo"))
+        PdfFileReader(io.BytesIO(b"foo"), strict=True)
     assert exc.value.args[0] == "PDF starts with 'foo', but '%PDF-' expected"
 
 
 def test_read_malformed_body():
     with pytest.raises(PdfReadError) as exc:
-        PdfFileReader(io.BytesIO(b"%PDF-"))
+        PdfFileReader(io.BytesIO(b"%PDF-"), strict=True)
     assert exc.value.args[0] == "Could not read malformed PDF file"
 
 


### PR DESCRIPTION
It's expected that this is a more sensible default for most users.