### PR TITLE
MAINT: Use Python 3.6 language features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -13,7 +13,7 @@ Replace this: What happened? What were you trying to achieve?
 
 Which environment were you using when you encountered the problem?
 
-```python
+```bash
 $ python -m platform
 # TODO: Your output goes here
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: end-of-file-fixer
+        exclude: "resources/.*"
     -   id: trailing-whitespace
     -   id: mixed-line-ending
     -   id: check-added-large-files
@@ -45,3 +46,8 @@ repos:
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==22.1.0]
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2006, Mathieu Fenniak
 # Copyright (c) 2007, Ashish Kulkarni <kulkarni.ashish@gmail.com>
 #

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2006, Mathieu Fenniak
 # Copyright (c) 2007, Ashish Kulkarni <kulkarni.ashish@gmail.com>
 #
@@ -168,7 +166,7 @@ class DocumentInformation(DictionaryObject):
         return self.get(DI.PRODUCER)
 
 
-class PdfFileReader(object):
+class PdfFileReader:
     """
     Initialize a PdfFileReader object.
 
@@ -862,7 +860,7 @@ class PdfFileReader(object):
 
     def cacheIndirectObject(self, generation, idnum, obj):
         if (generation, idnum) in self.resolvedObjects:
-            msg = "Overwriting cache for %s %s" % (generation, idnum)
+            msg = f"Overwriting cache for {generation} {idnum}"
             if self.strict:
                 raise PdfReadError(msg)
             else:
@@ -900,7 +898,7 @@ class PdfFileReader(object):
             raise PdfReadError("Broken xref table")
         else:
             warnings.warn(
-                "incorrect startxref pointer({})".format(xref_issue_nr), PdfReadWarning
+                f"incorrect startxref pointer({xref_issue_nr})", PdfReadWarning
             )
 
         # read all cross reference tables and their trailers

--- a/PyPDF2/_security.py
+++ b/PyPDF2/_security.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2006, Mathieu Fenniak
 # Copyright (c) 2007, Ashish Kulkarni <kulkarni.ashish@gmail.com>
 #

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2006, Mathieu Fenniak
 # Copyright (c) 2007, Ashish Kulkarni <kulkarni.ashish@gmail.com>
 #
@@ -69,7 +67,7 @@ from PyPDF2.utils import b_
 logger = logging.getLogger(__name__)
 
 
-class PdfFileWriter(object):
+class PdfFileWriter:
     """
     This class supports writing PDF files out, given pages produced by another
     class (typically :class:`PdfFileReader<PdfFileReader>`).
@@ -634,7 +632,7 @@ class PdfFileWriter(object):
             else:
                 if hasattr(data.pdf, "stream") and data.pdf.stream.closed:
                     raise ValueError(
-                        "I/O operation on closed file: {}".format(data.pdf.stream.name)
+                        f"I/O operation on closed file: {data.pdf.stream.name}"
                     )
                 newobj = (
                     externMap.get(data.pdf, {})
@@ -771,7 +769,7 @@ class PdfFileWriter(object):
         bold=False,
         italic=False,
         fit="/Fit",
-        *args
+        *args,
     ):
         """
         Add a bookmark to this PDF file.

--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006, Mathieu Fenniak
 # All rights reserved.
 #
@@ -121,7 +120,7 @@ except ImportError:  # pragma: no cover
         return retval
 
 
-class FlateDecode(object):
+class FlateDecode:
     @staticmethod
     def decode(data, decodeParms):
         """
@@ -203,7 +202,7 @@ class FlateDecode(object):
         return compress(data)
 
 
-class ASCIIHexDecode(object):
+class ASCIIHexDecode:
     """
     The ASCIIHexDecode filter decodes data that has been encoded in ASCII
     hexadecimal form into a base-7 ASCII format.
@@ -239,12 +238,12 @@ class ASCIIHexDecode(object):
         return retval
 
 
-class LZWDecode(object):
+class LZWDecode:
     """Taken from:
     http://www.java2s.com/Open-Source/Java-Document/PDF/PDF-Renderer/com/sun/pdfview/decode/LZWDecode.java.htm
     """
 
-    class decoder(object):
+    class decoder:
         def __init__(self, data):
             self.STOP = 257
             self.CLEARDICT = 256
@@ -334,7 +333,7 @@ class LZWDecode(object):
         return LZWDecode.decoder(data).decode()
 
 
-class ASCII85Decode(object):
+class ASCII85Decode:
     """Decodes string ASCII85-encoded data into a byte format."""
 
     @staticmethod
@@ -362,19 +361,19 @@ class ASCII85Decode(object):
         return bytes(out)
 
 
-class DCTDecode(object):
+class DCTDecode:
     @staticmethod
     def decode(data, decodeParms=None):
         return data
 
 
-class JPXDecode(object):
+class JPXDecode:
     @staticmethod
     def decode(data, decodeParms=None):
         return data
 
 
-class CCITParameters(object):
+class CCITParameters:
     """TABLE 3.9 Optional parameters for the CCITTFaxDecode filter"""
 
     def __init__(self, K=0, columns=0, rows=0):
@@ -397,7 +396,7 @@ class CCITParameters(object):
         return CCITTgroup
 
 
-class CCITTFaxDecode(object):
+class CCITTFaxDecode:
     """
     See 3.3.5 CCITTFaxDecode Filter (PDF 1.7 Standard).
 

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006, Mathieu Fenniak
 # All rights reserved.
 #
@@ -102,7 +101,7 @@ def readObject(stream, pdf):
             return NumberObject.readFromStream(stream)
 
 
-class PdfObject(object):
+class PdfObject:
     def getObject(self):
         """Resolve indirect references."""
         return self
@@ -182,7 +181,7 @@ class IndirectObject(PdfObject):
         return self.pdf.getObject(self).getObject()
 
     def __repr__(self):
-        return "IndirectObject(%r, %r)" % (self.idnum, self.generation)
+        return f"IndirectObject({self.idnum!r}, {self.generation!r})"
 
     def __eq__(self, other):
         return (
@@ -197,7 +196,7 @@ class IndirectObject(PdfObject):
         return not self.__eq__(other)
 
     def writeToStream(self, stream, encryption_key):
-        stream.write(b_("%s %s R" % (self.idnum, self.generation)))
+        stream.write(b_(f"{self.idnum} {self.generation} R"))
 
     @staticmethod
     def readFromStream(stream, pdf):
@@ -238,7 +237,7 @@ class FloatObject(decimal.Decimal, PdfObject):
             except decimal.InvalidOperation:
                 # If this isn't a valid decimal (happens in malformed PDFs)
                 # fallback to 0
-                logger.warning("Invalid FloatObject {}".format(value))
+                logger.warning(f"Invalid FloatObject {value}")
                 return decimal.Decimal.__new__(cls, "0")
 
     def __repr__(self):
@@ -1077,16 +1076,16 @@ class RectangleObject(ArrayObject):
         return self.getUpperRight_x(), self.getUpperRight_y()
 
     def setLowerLeft(self, value):
-        self[0], self[1] = [self.ensureIsNumber(x) for x in value]
+        self[0], self[1] = (self.ensureIsNumber(x) for x in value)
 
     def setLowerRight(self, value):
-        self[2], self[1] = [self.ensureIsNumber(x) for x in value]
+        self[2], self[1] = (self.ensureIsNumber(x) for x in value)
 
     def setUpperLeft(self, value):
-        self[0], self[3] = [self.ensureIsNumber(x) for x in value]
+        self[0], self[3] = (self.ensureIsNumber(x) for x in value)
 
     def setUpperRight(self, value):
-        self[2], self[3] = [self.ensureIsNumber(x) for x in value]
+        self[2], self[3] = (self.ensureIsNumber(x) for x in value)
 
     def getWidth(self):
         return self.getUpperRight_x() - self.getLowerLeft_x()

--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -38,7 +38,7 @@ from PyPDF2.utils import str_
 StreamIO = BytesIO
 
 
-class _MergedPage(object):
+class _MergedPage:
     """
     _MergedPage is used internally by PdfFileMerger to collect necessary
     information on each page that is being merged.
@@ -51,7 +51,7 @@ class _MergedPage(object):
         self.id = id
 
 
-class PdfFileMerger(object):
+class PdfFileMerger:
     """
     Initializes a ``PdfFileMerger`` object. ``PdfFileMerger`` merges multiple
     PDFs into a single PDF. It can concatenate, slice, insert, or any
@@ -466,7 +466,9 @@ class PdfFileMerger(object):
             if pageno is not None:
                 nd[NameObject("/Page")] = NumberObject(pageno)
             else:
-                raise ValueError("Unresolved named destination '%s'" % (nd["/Title"],))
+                raise ValueError(
+                    "Unresolved named destination '{}'".format(nd["/Title"])
+                )
 
     def _associate_bookmarks_to_pages(self, pages, bookmarks=None):
         if bookmarks is None:
@@ -490,7 +492,7 @@ class PdfFileMerger(object):
             if pageno is not None:
                 b[NameObject("/Page")] = NumberObject(pageno)
             else:
-                raise ValueError("Unresolved bookmark '%s'" % (b["/Title"],))
+                raise ValueError("Unresolved bookmark '{}'".format(b["/Title"]))
 
     def findBookmark(self, bookmark, root=None):
         if root is None:

--- a/PyPDF2/pagerange.py
+++ b/PyPDF2/pagerange.py
@@ -30,7 +30,7 @@ PAGE_RANGE_HELP = """Remember, page indices start with zero.
 """
 
 
-class PageRange(object):
+class PageRange:
     """
     A slice-like representation of a range of page indices,
         i.e. page numbers, only starting at zero.

--- a/PyPDF2/papersizes.py
+++ b/PyPDF2/papersizes.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 Dimensions = namedtuple("Dimensions", ["width", "height"])
 
 
-class PaperSize(object):
+class PaperSize:
     """(width, height) of the paper in portrait mode in pixels at 72 ppi."""
 
     # Notes how to calculate it:

--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -110,7 +110,7 @@ def readUntilRegex(stream, regex, ignore_eof=False):
     return name
 
 
-class ConvertFunctionsToVirtualList(object):
+class ConvertFunctionsToVirtualList:
     def __init__(self, lengthFunction, getFunction):
         self.lengthFunction = lengthFunction
         self.getFunction = getFunction
@@ -153,7 +153,7 @@ def RC4_encrypt(key, plaintext):
 
 def matrixMultiply(a, b):
     return [
-        [sum([float(i) * float(j) for i, j in zip(row, col)]) for col in zip(*b)]
+        [sum(float(i) * float(j) for i, j in zip(row, col)) for col in zip(*b)]
         for row in a
     ]
 

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -74,8 +74,7 @@ class XmpInformation(PdfObject):
                 attr = desc.getAttributeNodeNS(namespace, name)
                 if attr is not None:
                     yield attr
-                for element in desc.getElementsByTagNameNS(namespace, name):
-                    yield element
+                yield from desc.getElementsByTagNameNS(namespace, name)
 
     def getNodesInNamespace(self, aboutUri, namespace):
         for desc in self.rdfRoot.getElementsByTagNameNS(RDF_NAMESPACE, "Description"):
@@ -116,7 +115,7 @@ class XmpInformation(PdfObject):
         tzd = matches.group("tzd") or "Z"
         dt = datetime.datetime(year, month, day, hour, minute, seconds, milliseconds)
         if tzd != "Z":
-            tzd_hours, tzd_minutes = [int(x) for x in tzd.split(":")]
+            tzd_hours, tzd_minutes = (int(x) for x in tzd.split(":"))
             tzd_hours *= -1
             if tzd_hours < 0:
                 tzd_minutes *= -1

--- a/make_changelog.py
+++ b/make_changelog.py
@@ -42,7 +42,7 @@ def version_bump(git_tag: str) -> str:
 
 
 def get_changelog(changelog_path: str) -> str:
-    with open(changelog_path, "r") as fh:
+    with open(changelog_path) as fh:
         changelog = fh.read()
     return changelog
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import re
 from setuptools import setup
 
 VERSIONFILE = "PyPDF2/_version.py"
-with open(VERSIONFILE, "rt") as fp:
+with open(VERSIONFILE) as fp:
     verstrline = fp.read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
 mo = re.search(VSRE, verstrline, re.M)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import string
 from itertools import product as cartesian_product
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from io import BytesIO
 
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import io
 import os
 
@@ -94,6 +93,6 @@ def test_hexStr():
 
 def test_b():
     assert PyPDF2.utils.b_("foo") == b"foo"
-    assert PyPDF2.utils.b_("😀") == "😀".encode("utf-8")
-    assert PyPDF2.utils.b_("‰") == "‰".encode("utf-8")
-    assert PyPDF2.utils.b_("▷") == "▷".encode("utf-8")
+    assert PyPDF2.utils.b_("😀") == "😀".encode()
+    assert PyPDF2.utils.b_("‰") == "‰".encode()
+    assert PyPDF2.utils.b_("▷") == "▷".encode()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import binascii
 import os
 import sys
@@ -54,7 +52,7 @@ def test_PdfReaderJpegImage():
         reader = PdfFileReader(inputfile)
 
         # Retrieve the text of the image
-        with open(os.path.join(RESOURCE_ROOT, "jpeg.txt"), "r") as pdftext_file:
+        with open(os.path.join(RESOURCE_ROOT, "jpeg.txt")) as pdftext_file:
             imagetext = pdftext_file.read()
 
         page = reader.getPage(0)

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -25,7 +25,7 @@ def test_read_xmp(src, has_xmp):
         for el in xmp.getElement(
             aboutUri="", namespace=PyPDF2.xmp.RDF_NAMESPACE, name="Artist"
         ):
-            print("el={el}".format(el=el))
+            print(f"el={el}")
 
         assert get_all_tiff(xmp) == {"tiff:Artist": ["me"]}
         assert xmp.dc_contributor == []


### PR DESCRIPTION
As support for Python 3.5 and lower was dropped, we can use more modern syntax

Add pyupgrade to pre-commit hooks