### PR TITLE
WIP: support font CMAP to translate chars with TJ operator

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ indent='    '
 multi_line_output=3
 length_sort=0
 include_trailing_comma=True
-known_third_party = dataclasses,pytest,setuptools
+known_third_party = pytest,setuptools


### PR DESCRIPTION
Hello!

With this PR is possible to extractText from TJ operator, fixing the issues #576 and #654

It's adding support to CMAP translate when the PDF uses ToUnicode.

I need to add some tests on it yet.

Edit:
---
the issue #654 isn't fixed, I tested with the first link described in that issue, but the second link isn't returning text. I'm debug it, seems that the cmap table contains chars and bytes, if we convert the entire table to byte it will work.   