### PR TITLE
ci: release to pypi and github on tagged pushes.

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -86,6 +86,16 @@ jobs:
       - name: Check long_description
         run: python -m twine check dist/*
 
+      - name: Release to pypi if tagged.
+        if: startsWith(github.ref, "refs/tags")
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create Github release if tagged.
+        if: startsWith(github.ref, "refs/tags/")
+        uses: softprops/action-gh-release@v1
+
   coverage:
     name: Combine & check coverage.
     runs-on: ubuntu-latest

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -86,12 +86,12 @@ jobs:
       - name: Check long_description
         run: python -m twine check dist/*
 
-      - name: Release to pypi if tagged.
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Release to pypi if tagged.
+      #   if: startsWith(github.ref, 'refs/tags')
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Create Github release if tagged.
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -87,13 +87,13 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Release to pypi if tagged.
-        if: startsWith(github.ref, "refs/tags")
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Create Github release if tagged.
-        if: startsWith(github.ref, "refs/tags/")
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
 
   coverage:


### PR DESCRIPTION
Closes (hopefull) #748.
Untested, as would require credentials.

Uses:
https://github.com/softprops/action-gh-release
https://github.com/softprops/action-gh-release

Note that I personally use semantic-release in everything (in ci), which handles the releasing/tags/pypi etc all in one with decent changelogs.  But this is (hopefully) what was requested.