### PR TITLE
MAINT: Remove unnecessary generics imports

### DIFF
--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -35,7 +35,7 @@ import struct
 from io import StringIO
 from typing import Any, Dict, Optional, Tuple, Union
 
-from PyPDF2.generic import ArrayObject, DictionaryObject
+from PyPDF2.generic import ArrayObject, DictionaryObject, NameObject
 
 try:
     from typing import Literal  # type: ignore[attr-defined]
@@ -438,8 +438,6 @@ class CCITTFaxDecode:
         k = 0
         columns = 0
         if parameters:
-            from PyPDF2.generic import ArrayObject
-
             if isinstance(parameters, ArrayObject):
                 for decodeParm in parameters:
                     if CCITT.COLUMNS in decodeParm:
@@ -509,8 +507,6 @@ class CCITTFaxDecode:
 
 
 def decodeStreamData(stream: Any) -> Union[str, bytes]:  # utils.StreamObject
-    from PyPDF2.generic import NameObject
-
     filters = stream.get(SA.FILTER, ())
 
     if len(filters) and not isinstance(filters[0], NameObject):


### PR DESCRIPTION
This PR removes the nested imports from `PyPDF2.generic` in `PyPDF2.filters` as there's already a top-level import on that module for the typing information and so having additional nested imports provides no benefit at the cost of clutter. Additionally, one of the nested imports was for something that was already being imported at that top level.