### PR TITLE
BUG: Incorrectly show deprecation warnings on internal usage

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -39,10 +39,10 @@ from PyPDF2 import _utils
 from PyPDF2._page import PageObject
 from PyPDF2._security import RC4_encrypt, _alg33_1, _alg34, _alg35
 from PyPDF2._utils import (
-    ConvertFunctionsToVirtualList,
+    _isString,
+    _VirtualList,
     b_,
     formatWarning,
-    isString,
     readUntilWhitespace,
 )
 from PyPDF2.constants import CatalogAttributes as CA
@@ -267,7 +267,7 @@ class PdfReader(object):
                 "It may not be read correctly.",
                 PdfReadWarning,
             )
-        if isString(stream):
+        if _isString(stream):
             with open(stream, "rb") as fileobj:
                 stream = BytesIO(b_(fileobj.read()))
         self.read(stream)
@@ -873,7 +873,7 @@ class PdfReader(object):
         if dest:
             if isinstance(dest, ArrayObject):
                 outline = self._build_destination(title, dest)
-            elif isString(dest) and dest in self._namedDests:
+            elif _isString(dest) and dest in self._namedDests:
                 outline = self._namedDests[dest]
                 outline[NameObject("/Title")] = title
             else:
@@ -883,7 +883,7 @@ class PdfReader(object):
     @property
     def pages(self):
         """Read-only property that emulates a list of :py:class:`Page<PyPDF2._page.Page>` objects."""
-        return ConvertFunctionsToVirtualList(self._get_num_pages, self._get_page)
+        return _VirtualList(self._get_num_pages, self._get_page)
 
     @property
     def page_layout(self):

--- a/PyPDF2/_utils.py
+++ b/PyPDF2/_utils.py
@@ -66,23 +66,35 @@ DEPR_MSG_NO_REPLACEMENT = "{} is deprecated and will be removed in PyPDF2 2.0.0.
 DEPR_MSG = "{} is deprecated and will be removed in PyPDF2 2.0.0. Use {} instead."
 
 
+def _isString(s):
+    return isinstance(s, _basestring)
+
+
 # Make basic type tests more consistent
 def isString(s):
     """Test if arg is a string. Compatible with Python 2 and 3."""
     warnings.warn(DEPR_MSG_NO_REPLACEMENT.format("isString"))
-    return isinstance(s, _basestring)
+    return _isString(s)
+
+
+def _isInt(n):
+    return isinstance(n, int_types)
 
 
 def isInt(n):
     """Test if arg is an int. Compatible with Python 2 and 3."""
     warnings.warn(DEPR_MSG_NO_REPLACEMENT.format("isInt"))
-    return isinstance(n, int_types)
+    return _isInt(n)
+
+
+def _isBytes(b):
+    return isinstance(b, bytes_type)
 
 
 def isBytes(b):
     """Test if arg is a bytes instance. Compatible with Python 2 and 3."""
     warnings.warn(DEPR_MSG_NO_REPLACEMENT.format("isBytes"))
-    return isinstance(b, bytes_type)
+    return _isBytes(b)
 
 
 def formatWarning(message, category, filename, lineno, line=None):
@@ -162,13 +174,8 @@ def readUntilRegex(stream, regex, ignore_eof=False):
     return name
 
 
-class ConvertFunctionsToVirtualList(object):
+class _VirtualList(object):
     def __init__(self, lengthFunction, getFunction):
-        warnings.warn(
-            "ConvertFunctionsToVirtualList will be removed with PyPDF2 2.0.0",
-            PendingDeprecationWarning,
-        )
-        warnings.warn(DEPR_MSG_NO_REPLACEMENT.format("ConvertFunctionsToVirtualList"))
         self.lengthFunction = lengthFunction
         self.getFunction = getFunction
 
@@ -180,7 +187,7 @@ class ConvertFunctionsToVirtualList(object):
             indices = xrange_fn(*index.indices(len(self)))
             cls = type(self)
             return cls(indices.__len__, lambda idx: self[indices[idx]])
-        if not isInt(index):
+        if not _isInt(index):
             raise TypeError("sequence indices must be integers")
         len_self = len(self)
         if index < 0:
@@ -189,6 +196,17 @@ class ConvertFunctionsToVirtualList(object):
         if index < 0 or index >= len_self:
             raise IndexError("sequence index out of range")
         return self.getFunction(index)
+
+
+class ConvertFunctionsToVirtualList(_VirtualList):
+    def __init__(self, lengthFunction, getFunction):
+        warnings.warn(
+            "ConvertFunctionsToVirtualList will be removed with PyPDF2 2.0.0",
+            PendingDeprecationWarning,
+        )
+        warnings.warn(DEPR_MSG_NO_REPLACEMENT.format("ConvertFunctionsToVirtualList"))
+        super().__init__(lengthFunction, getFunction)
+
 
 
 def matrix_multiply(a, b):

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -39,10 +39,10 @@ from hashlib import md5
 from PyPDF2._page import PageObject
 from PyPDF2._security import _alg33, _alg34, _alg35
 from PyPDF2._utils import (
+    _isString,
+    _VirtualList,
     DEPR_MSG,
-    ConvertFunctionsToVirtualList,
     b_,
-    isString,
     u_,
 )
 from PyPDF2.constants import CatalogAttributes as CA
@@ -266,7 +266,7 @@ class PdfWriter(object):
         """
         Property that emulates a list of :class:`PageObject<PyPDF2._page.PageObject>`
         """
-        return ConvertFunctionsToVirtualList(self._get_num_pages, self.get_page)
+        return _VirtualList(self._get_num_pages, self.get_page)
 
     def add_blank_page(self, width=None, height=None):
         """
@@ -1351,7 +1351,7 @@ class PdfWriter(object):
         else:
             border_arr = [NumberObject(2)] * 3
 
-        if isString(rect):
+        if _isString(rect):
             rect = NameObject(rect)
         elif isinstance(rect, RectangleObject):
             pass
@@ -1445,7 +1445,7 @@ class PdfWriter(object):
         else:
             border_arr = [NumberObject(0)] * 3
 
-        if isString(rect):
+        if _isString(rect):
             rect = NameObject(rect)
         elif isinstance(rect, RectangleObject):
             pass

--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -28,7 +28,7 @@
 from sys import version_info
 
 from PyPDF2._reader import PdfReader
-from PyPDF2._utils import DEPR_MSG, isString, str_
+from PyPDF2._utils import _isString, DEPR_MSG, str_
 from PyPDF2._writer import PdfWriter
 from PyPDF2.constants import PagesAttributes as PA
 from PyPDF2.generic import *
@@ -128,7 +128,7 @@ class PdfMerger(object):
         # BytesIO (or StreamIO) stream.
         # If fileobj is none of the above types, it is not modified
         decryption_key = None
-        if isString(fileobj):
+        if _isString(fileobj):
             fileobj = file(fileobj, "rb")
             my_file = True
         elif hasattr(fileobj, "seek") and hasattr(fileobj, "read"):
@@ -239,7 +239,7 @@ class PdfMerger(object):
             file-like object.
         """
         my_file = False
-        if isString(fileobj):
+        if _isString(fileobj):
             fileobj = file(fileobj, "wb")
             my_file = True
 

--- a/PyPDF2/pagerange.py
+++ b/PyPDF2/pagerange.py
@@ -11,7 +11,7 @@ import re
 
 from PyPDF2.errors import ParseError
 
-from ._utils import isString
+from ._utils import _isString
 
 _INT_RE = r"(0|-?[1-9]\d*)"  # A decimal int, don't allow "-0".
 PAGE_RANGE_RE = "^({int}|({int}?(:{int}?(:{int}?)?)))$".format(int=_INT_RE)
@@ -71,7 +71,7 @@ class PageRange(object):
             self._slice = arg.to_slice()
             return
 
-        m = isString(arg) and re.match(PAGE_RANGE_RE, arg)
+        m = _isString(arg) and re.match(PAGE_RANGE_RE, arg)
         if not m:
             raise ParseError(arg)
         elif m.group(2):
@@ -89,7 +89,7 @@ class PageRange(object):
     def valid(input):
         """True if input is a valid initializer for a PageRange."""
         return isinstance(input, (slice, PageRange)) or (
-            isString(input) and bool(re.match(PAGE_RANGE_RE, input))
+            _isString(input) and bool(re.match(PAGE_RANGE_RE, input))
         )
 
     def to_slice(self):


### PR DESCRIPTION
Fixes #886

PR fixes a bug where the codebase was internally relying on deprecated functions and so would trigger the warnings even though there's no action the user could meaningful taken. Now, the internal usage relies on an internal version of the function that executes as before sans deprecation warning while leaving in place a user facing version of the function that has the deprecation warning (and relies on the new internal function to keep behavior consistent).