### PR TITLE
MAINT: Remove duplicate warnings imports

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -1815,8 +1815,6 @@ class PdfReader(object):
 
 class PdfFileReader(PdfReader):
     def __init__(self, *args, **kwargs):
-        import warnings
-
         warnings.warn(
             "PdfFileReader was renamed to PdfReader. PdfFileReader will be removed",
             PendingDeprecationWarning,

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -1752,8 +1752,6 @@ class PdfWriter(object):
 
 class PdfFileWriter(PdfWriter):
     def __init__(self, *args, **kwargs):
-        import warnings
-
         warnings.warn(
             "PdfFileWriter was renamed to PdfWriter. PdfFileWriter will be removed",
             PendingDeprecationWarning,

--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from sys import version_info
+import warnings
 
 from PyPDF2._reader import PdfReader
 from PyPDF2._utils import DEPR_MSG, isString, str_
@@ -748,8 +749,6 @@ class OutlinesObject(list):
 
 class PdfFileMerger(PdfMerger):
     def __init__(self, *args, **kwargs):
-        import warnings
-
         warnings.warn(
             "PdfFileMerger was renamed to PdfMerger. PdfFileMerger will be removed",
             PendingDeprecationWarning,


### PR DESCRIPTION
This PR removes a handful of places where `warnings` module was being double imported (once at the top-level and once within a method), leaving in place just the top-level import.