### PR TITLE
BUG: Fix UserWarning on reading outlines

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -710,7 +710,7 @@ class PdfReader:
             # check for sub-outlines
             if "/First" in node:
                 sub_outlines: List[Any] = []
-                self.getOutlines(cast(DictionaryObject, node["/First"]), sub_outlines)
+                self.get_outlines(cast(DictionaryObject, node["/First"]), sub_outlines)
                 if sub_outlines:
                     outlines.append(sub_outlines)
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -77,7 +77,7 @@ def merge():
 
     # Check if bookmarks are correct
     pdfr = PyPDF2.PdfReader(tmp_path)
-    assert [el.title for el in pdfr.getOutlines() if isinstance(el, Destination)] == [
+    assert [el.title for el in pdfr.get_outlines() if isinstance(el, Destination)] == [
         "A bookmark",
         "Foo",
         "Bar",

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -50,7 +50,7 @@ def test_merge():
 
     # Check if bookmarks are correct
     pdfr = PyPDF2.PdfReader(tmp_path)
-    assert [el.title for el in pdfr.getOutlines() if isinstance(el, Destination)] == [
+    assert [el.title for el in pdfr.get_outlines() if isinstance(el, Destination)] == [
         "A bookmark",
         "Foo",
         "Bar",

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -129,7 +129,7 @@ def test_get_attachments(src):
 )
 def test_get_outlines(src, outline_elements):
     reader = PdfReader(src)
-    outlines = reader.getOutlines()
+    outlines = reader.get_outlines()
     assert len(outlines) == outline_elements
 
 
@@ -494,7 +494,7 @@ def test_read_encrypted_without_decryption():
 def test_get_destination_page_number():
     src = os.path.join(RESOURCE_ROOT, "pdflatex-outline.pdf")
     reader = PdfReader(src)
-    outlines = reader.getOutlines()
+    outlines = reader.get_outlines()
     for outline in outlines:
         if not isinstance(outline, list):
             reader.get_destination_page_number(outline)
@@ -551,13 +551,13 @@ def test_issue604(strict):
         if strict:
             with pytest.raises(PdfReadError) as exc:
                 pdf = PdfReader(f, strict=strict)
-                bookmarks = pdf.getOutlines()
+                bookmarks = pdf.get_outlines()
             if "Unknown Destination" not in exc.value.args[0]:
                 raise Exception("Expected exception not raised")
             return  # bookmarks not correct
         else:
             pdf = PdfReader(f, strict=strict)
-            bookmarks = pdf.getOutlines()
+            bookmarks = pdf.get_outlines()
 
         def getDestPages(x):
             # print(x)


### PR DESCRIPTION
PR fixes a bug where a deprecation UserWarning would be raised when fetching outlines on a reader where an outline has a sub-outline.

Additionally, I also modified all tests to also use `get_outlines` instead of `getOutlines`.

As an aside, should `get_outlines` similar be deprecated and push users to the `outlines` property instead? Feels weird to have both `reader.outlines` and `reader.get_outlines()` and they do the same thing and that violates the "Zen of Python".

Also, 1.x branch already has these changes done already.