### PR TITLE
BUG: Fix PendingDeprecationWarning on merge/transform PageObject

### DIFF
--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -603,8 +603,8 @@ class PageObject(DictionaryObject):
                 max(corners1[3], upperright[1]),
             )
 
-            self.mediabox.setLowerLeft(lowerleft)
-            self.mediabox.setUpperRight(upperright)
+            self.mediabox.lower_left = lowerleft
+            self.mediabox.upper_right = upperright
 
         self[NameObject(PG.CONTENTS)] = ContentStream(new_content_array, self.pdf)
         self[NameObject(PG.RESOURCES)] = new_resources
@@ -919,8 +919,8 @@ class PageObject(DictionaryObject):
                 max(corners[3], upperright[1]),
             )
 
-            self.mediabox.setLowerLeft(lowerleft)
-            self.mediabox.setUpperRight(upperright)
+            self.mediabox.lower_left = lowerleft
+            self.mediabox.upper_right = upperright
         self[NameObject(PG.CONTENTS)] = content
 
     def addTransformation(self, ctm: CompressedTransformationMatrix) -> None:

--- a/tests/test_basic_features.py
+++ b/tests/test_basic_features.py
@@ -37,7 +37,7 @@ def test_basic_features():
 
     # add page 5 from input1, but crop it to half size:
     page5 = reader.pages[0]
-    page5.mediabox.upperRight = (
+    page5.mediabox.upper_right = (
         page5.mediabox.right / 2,
         page5.mediabox.top / 2,
     )


### PR DESCRIPTION
PR fixes a PendingDeprecationWarning that was raised when you attempted to merge or transform a PageObject as it referenced the old camel-case version of the method instead of using the property.

Note: This PR can be backported (hopefully as-is) to 1.x branch.,