### PR TITLE
TST: Improve tests for convert_to_int

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -94,7 +94,7 @@ from .xmp import XmpInformation
 
 def convert_to_int(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
     if size > 8:
-        raise PdfReadError("invalid size in convertToInt")
+        raise PdfReadError("invalid size in convert_to_int")
     d = b_("\x00\x00\x00\x00\x00\x00\x00\x00") + b_(d)
     d = d[-8:]
     return struct.unpack(">q", d)[0]

--- a/tests/test_basic_features.py
+++ b/tests/test_basic_features.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 from PyPDF2 import PdfReader, PdfWriter
 
 TESTS_ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_basic_features.py
+++ b/tests/test_basic_features.py
@@ -3,8 +3,6 @@ import os
 import pytest
 
 from PyPDF2 import PdfReader, PdfWriter
-from PyPDF2._reader import convertToInt
-from PyPDF2.errors import PdfReadError
 
 TESTS_ROOT = os.path.abspath(os.path.dirname(__file__))
 PROJECT_ROOT = os.path.dirname(TESTS_ROOT)
@@ -59,9 +57,3 @@ def test_basic_features():
 
     # cleanup
     os.remove(tmp_path)
-
-
-def test_convertToInt():
-    with pytest.raises(PdfReadError) as exc:
-        convertToInt(b"256", 16)
-    assert exc.value.args[0] == "invalid size in convertToInt"

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -6,6 +6,7 @@ from io import BytesIO
 import pytest
 
 from PyPDF2 import PdfReader
+from PyPDF2._reader import convert_to_int, convertToInt
 from PyPDF2.constants import ImageAttributes as IA
 from PyPDF2.constants import PageAttributes as PG
 from PyPDF2.constants import Ressources as RES
@@ -603,3 +604,18 @@ def test_VirtualList():
 
     # Test if getting as slice throws an error
     assert len(reader.pages[:]) == 1
+
+
+def test_convert_to_int():
+    assert convert_to_int(b'\x01') == 1
+
+
+def test_convert_to_int_error():
+    with pytest.raises(PdfReadError) as exc:
+        convert_to_int(b"256", 16)
+    assert exc.value.args[0] == "invalid size in convert_to_int"
+
+
+def test_convertToInt_deprecated():
+    with pytest.warns(PendingDeprecationWarning, "convertToInt will be removed with PyPDF2 2.0.0. Use convert_to_int instead."):
+        assert convertToInt(b'\x01') == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -617,5 +617,5 @@ def test_convert_to_int_error():
 
 
 def test_convertToInt_deprecated():
-    with pytest.warns(PendingDeprecationWarning, "convertToInt will be removed with PyPDF2 2.0.0. Use convert_to_int instead."):
+    with pytest.warns(PendingDeprecationWarning, match="convertToInt will be removed with PyPDF2 2.0.0. Use convert_to_int instead."):
         assert convertToInt(b'\x01', 8) == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -607,7 +607,7 @@ def test_VirtualList():
 
 
 def test_convert_to_int():
-    assert convert_to_int(b'\x01') == 1
+    assert convert_to_int(b'\x01', 8) == 1
 
 
 def test_convert_to_int_error():
@@ -618,4 +618,4 @@ def test_convert_to_int_error():
 
 def test_convertToInt_deprecated():
     with pytest.warns(PendingDeprecationWarning, "convertToInt will be removed with PyPDF2 2.0.0. Use convert_to_int instead."):
-        assert convertToInt(b'\x01') == 1
+        assert convertToInt(b'\x01', 8) == 1


### PR DESCRIPTION
PR update the test suite so that the `convert_to_int` function is principally tested instead of `convertToInt`. I've also added another test case for `convert_to_int` that minimally covers the happy path, as well as a test that `convertToInt` does raise a pending deprecation warning.

I moved the tests from `tests/test_basic_features.py` to `tests/test_reader.py` as these methods are not part of the public API, and so I think makes more sense to be in the test file for the module they live in.