### PR TITLE
DEP: PEP8 renaming

### DIFF
--- a/PyPDF2/_merger.py
+++ b/PyPDF2/_merger.py
@@ -690,7 +690,7 @@ class PdfMerger:
         dest = Destination(
             NameObject("/" + title + " bookmark"), page_ref, NameObject(fit), *zoom_args
         )
-        dest_array = dest.getDestArray()
+        dest_array = dest.dest_array
         action.update(
             {NameObject("/D"): dest_array, NameObject("/S"): NameObject("/GoTo")}
         )

--- a/PyPDF2/_merger.py
+++ b/PyPDF2/_merger.py
@@ -149,7 +149,7 @@ class PdfMerger:
 
         outline = []
         if import_bookmarks:
-            outline = reader.get_outlines()
+            outline = reader.outlines
             outline = self._trim_outline(reader, outline, pages)
 
         if bookmark:
@@ -296,7 +296,7 @@ class PdfMerger:
         usage.
         """
         self.pages = []
-        for fo, _pdfr, mine in self.inputs:
+        for fo, _reader, mine in self.inputs:
             if mine:
                 fo.close()
 

--- a/PyPDF2/_merger.py
+++ b/PyPDF2/_merger.py
@@ -162,7 +162,7 @@ class PdfMerger:
         else:
             self.bookmarks += outline
 
-        dests = reader.namedDestinations
+        dests = reader.named_destinations
         trimmed_dests = self._trim_dests(reader, dests, pages)
         self.named_dests += trimmed_dests
 

--- a/PyPDF2/_merger.py
+++ b/PyPDF2/_merger.py
@@ -743,18 +743,6 @@ class PdfMerger:
 
     def add_named_destination(self, title: str, pagenum: int) -> None:
         """
-        .. deprecated:: 1.28.0
-            Use :meth:`add_named_destionation` instead.
-        """
-        warnings.warn(
-            "addNamedDestination is deprecated. Use add_named_destionation instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.add_named_destionation(title, pagenum)
-
-    def add_named_destionation(self, title: str, pagenum: int) -> None:
-        """
         Add a destination to the output.
 
         :param str title: Title to use

--- a/PyPDF2/_merger.py
+++ b/PyPDF2/_merger.py
@@ -726,7 +726,7 @@ class PdfMerger:
         bookmark_ref = self.output._add_object(bookmark)
         parent = cast(Bookmark, parent.get_object())
         assert parent is not None, "hint for mypy"
-        parent.addChild(bookmark_ref, self.output)
+        parent.add_child(bookmark_ref, self.output)
 
         return bookmark_ref
 

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -160,7 +160,7 @@ class Transformation:
     -----
     >>> from PyPDF2 import Transformation
     >>> op = Transformation().scale(sx=2, sy=3).translate(tx=10, ty=20)
-    >>> page.mergeTransformedPage(page2, op)
+    >>> page.add_transformation(op)
     """
 
     # 9.5.4 Coordinate Systems for 3D
@@ -228,7 +228,7 @@ class PageObject(DictionaryObject):
     :meth:`get_page()<PyPDF2.PdfReader.get_page>` method of the
     :class:`PdfReader<PyPDF2.PdfReader>` class, but it is
     also possible to create an empty page with the
-    :meth:`createBlankPage()<PageObject.createBlankPage>` static method.
+    :meth:`create_blank_page()<PyPDF2._page.PageObject.create_blank_page>` static method.
 
     :param pdf: PDF file the page belongs to.
     :param indirect_ref: Stores the original indirect reference to

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -1033,7 +1033,7 @@ class PageObject(DictionaryObject):
         if content is not None:
             if not isinstance(content, ContentStream):
                 content = ContentStream(content, self.pdf)
-            self[NameObject(PG.CONTENTS)] = content.flateEncode()
+            self[NameObject(PG.CONTENTS)] = content.flate_encode()
 
     def compressContentStreams(self) -> None:
         """

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -634,6 +634,8 @@ class PageObject(DictionaryObject):
         warnings.warn(
             "page.mergeTransformedPage(page2, ctm) will be removed in PyPDF 2.0.0. "
             "Use page2.add_transformation(ctm); page.merge_page(page2) instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         if isinstance(ctm, Transformation):
             ctm = ctm.ctm
@@ -831,7 +833,7 @@ class PageObject(DictionaryObject):
         op = Transformation().scale(scale, scale).translate(tx, ty)
         return self.mergeTransformedPage(page2, op, expand)
 
-    def merge_rotated_scaled_translated_page(
+    def mergeRotatedScaledTranslatedPage(
         self,
         page2: "PageObject",
         rotation: float,
@@ -870,7 +872,9 @@ class PageObject(DictionaryObject):
         self.mergeTransformedPage(page2, op, expand)
 
     def add_transformation(
-        self, ctm: CompressedTransformationMatrix, expand: bool = False
+        self,
+        ctm: Union[Transformation, CompressedTransformationMatrix],
+        expand: bool = False,
     ) -> None:
         """
         Apply a transformation matrix to the page.
@@ -1112,6 +1116,8 @@ class PageObject(DictionaryObject):
         """
         warnings.warn(
             DEPR_MSG.format("Page.extractText", "Page.extract_text"),
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self.extract_text(Tj_sep=Tj_sep, TJ_sep=TJ_sep)
 

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -112,8 +112,7 @@ def convertToInt(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
 class DocumentInformation(DictionaryObject):
     """
     A class representing the basic document metadata provided in a PDF File.
-    This class is accessible through
-    :meth:`.getDocumentInfo()`
+    This class is accessible through :py:class:`PdfReader.metadata<PyPDF2.PdfReader.metadata>`.
 
     All text properties of the document metadata have
     *two* properties, eg. author and author_raw. The non-raw property will

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -724,10 +724,10 @@ class PdfReader:
         """
         .. deprecated:: 1.28.0
 
-            Use :meth:`get_outlines` instead.
+            Use :py:attr:`outlines` instead.
         """
         warnings.warn(
-            "getOutlines will be removed in PyPDF2 2.0.0. Use get_outlines instead.",
+            "getOutlines will be removed in PyPDF2 2.0.0. Use the outlines attribute instead.",
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -667,17 +667,16 @@ class PdfReader:
 
     @property
     def outlines(self) -> OutlinesType:
-        """Read-only property."""
-        return self.get_outlines()
-
-    def get_outlines(
-        self, node: Optional[DictionaryObject] = None, outlines: Optional[Any] = None
-    ) -> OutlinesType:
         """
-        Retrieve the document outline present in the document.
+        Read-only property for outlines present in the document.
 
         :return: a nested list of :class:`Destinations<PyPDF2.generic.Destination>`.
         """
+        return self._get_outlines()
+
+    def _get_outlines(
+        self, node: Optional[DictionaryObject] = None, outlines: Optional[Any] = None
+    ) -> OutlinesType:
         if outlines is None:
             outlines = []
             catalog = cast(DictionaryObject, self.trailer[TK.ROOT])
@@ -709,7 +708,7 @@ class PdfReader:
             # check for sub-outlines
             if "/First" in node:
                 sub_outlines: List[Any] = []
-                self.get_outlines(cast(DictionaryObject, node["/First"]), sub_outlines)
+                self._get_outlines(cast(DictionaryObject, node["/First"]), sub_outlines)
                 if sub_outlines:
                     outlines.append(sub_outlines)
 
@@ -732,7 +731,7 @@ class PdfReader:
             PendingDeprecationWarning,
             stacklevel=2,
         )
-        return self.get_outlines(node, outlines)
+        return self._get_outlines(node, outlines)
 
     def _get_page_number_by_indirect(
         self, indirect_ref: Union[None, int, NullObject, IndirectObject]

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -105,6 +105,7 @@ def convertToInt(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
         "convertToInt will be removed with PyPDF2 2.0.0. "
         "Use convert_to_int instead.",
         PendingDeprecationWarning,
+        stacklevel=2,
     )
     return convert_to_int(d, size)
 
@@ -315,7 +316,7 @@ class PdfReader:
         """
         try:
             self._override_encryption = True
-            return self.trailer[TK.ROOT].getXmpMetadata()  # type: ignore
+            return self.trailer[TK.ROOT].xmp_metadata  # type: ignore
         finally:
             self._override_encryption = False
 
@@ -432,6 +433,8 @@ class PdfReader:
         warnings.warn(
             "namedDestinations will be removed in PyPDF2 2.0.0. "
             "Use `named_destinations` instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self.named_destinations
 
@@ -812,7 +815,7 @@ class PdfReader:
         try:
             return Destination(title, page, typ, *array)  # type: ignore
         except PdfReadError:
-            warnings.warn("Unknown destination : " + title + " " + str(array))
+            warnings.warn(f"Unknown destination: {title} {array}", PdfReadWarning)
             if self.strict:
                 raise
             else:
@@ -1409,7 +1412,7 @@ class PdfReader:
             if not line.startswith(b_("startxref")):
                 raise PdfReadError("startxref not found")
             startxref = int(line[9:].strip())
-            warnings.warn("startxref on same line as offset")
+            warnings.warn("startxref on same line as offset", PdfReadWarning)
         else:
             line = self.read_next_end_line(stream)
             if line[:9] != b_("startxref"):

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -1805,7 +1805,7 @@ class PdfReader:
         """
         Read-only boolean property showing whether this PDF file is encrypted.
         Note that this property, if true, will remain true even after the
-        :meth:`decrypt()<PdfReader.decrypt>` method is called.
+        :meth:`decrypt()<PyPDF2.PdfReader.decrypt>` method is called.
         """
         return TK.ENCRYPT in self.trailer
 

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -1029,7 +1029,7 @@ class PdfReader:
         assert obj_stm["/Type"] == "/ObjStm"
         # /N is the number of indirect objects in the stream
         assert idx < obj_stm["/N"]
-        stream_data = BytesIO(b_(obj_stm.getData()))  # type: ignore
+        stream_data = BytesIO(b_(obj_stm.get_data()))  # type: ignore
         for i in range(obj_stm["/N"]):  # type: ignore
             read_non_whitespace(stream_data)
             stream_data.seek(-1, 1)
@@ -1496,7 +1496,7 @@ class PdfReader:
         xrefstream = cast(ContentStream, read_object(stream, self))
         assert xrefstream["/Type"] == "/XRef"
         self.cache_indirect_object(generation, idnum, xrefstream)
-        stream_data = BytesIO(b_(xrefstream.getData()))
+        stream_data = BytesIO(b_(xrefstream.get_data()))
         # Index pairs specify the subsections in the dictionary. If
         # none create one subsection that spans everything.
         idx_pairs = xrefstream.get("/Index", [0, xrefstream.get("/Size")])

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -85,7 +85,7 @@ logger = logging.getLogger(__name__)
 class PdfWriter:
     """
     This class supports writing PDF files out, given pages produced by another
-    class (typically :class:`PdfReader<PdfReader>`).
+    class (typically :class:`PdfReader<PyPDF2.PdfReader>`).
     """
 
     def __init__(self) -> None:
@@ -183,7 +183,7 @@ class PdfWriter:
     def add_page(self, page: PageObject) -> None:
         """
         Add a page to this PDF file.  The page is usually acquired from a
-        :class:`PdfReader<PdfReader>` instance.
+        :class:`PdfReader<PyPDF2.PdfReader>` instance.
 
         :param PageObject page: The page to add to the document. Should be
             an instance of :class:`PageObject<PyPDF2._page.PageObject>`
@@ -206,7 +206,7 @@ class PdfWriter:
     def insert_page(self, page: PageObject, index: int = 0) -> None:
         """
         Insert a page in this PDF file. The page is usually acquired from a
-        :class:`PdfReader<PdfReader>` instance.
+        :class:`PdfReader<PyPDF2.PdfReader>` instance.
 
         :param PageObject page: The page to add to the document.  This
             argument should be an instance of :class:`PageObject<PyPDF2._page.PageObject>`.

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -1136,7 +1136,7 @@ class PdfWriter:
         dest = Destination(
             NameObject("/" + title + " bookmark"), page_ref, NameObject(fit), *zoom_args
         )
-        dest_array = dest.getDestArray()
+        dest_array = dest.dest_array
         action.update(
             {NameObject("/D"): dest_array, NameObject("/S"): NameObject("/GoTo")}
         )
@@ -1579,7 +1579,7 @@ class PdfWriter:
         dest = Destination(
             NameObject("/LinkName"), page_dest, NameObject(fit), *zoom_args
         )  # TODO: create a better name for the link
-        dest_array = dest.getDestArray()
+        dest_array = dest.dest_array
 
         lnk = DictionaryObject()
         lnk.update(

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -1040,7 +1040,7 @@ class PdfWriter:
             parent = outline_ref
 
         parent = cast(TreeObject, parent.get_object())
-        parent.addChild(dest_ref, self)
+        parent.add_child(dest_ref, self)
 
         return dest_ref
 
@@ -1082,7 +1082,7 @@ class PdfWriter:
 
         parent = parent.get_object()  # type: ignore
         assert parent is not None, "hint for mypy"
-        parent.addChild(bookmark_ref, self)
+        parent.add_child(bookmark_ref, self)
 
         return bookmark_ref
 
@@ -1173,7 +1173,7 @@ class PdfWriter:
 
         assert parent is not None, "hint for mypy"
         parent_obj = cast(TreeObject, parent.get_object())
-        parent_obj.addChild(bookmark_ref, self)
+        parent_obj.add_child(bookmark_ref, self)
 
         return bookmark_ref
 

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -447,7 +447,7 @@ class PdfWriter:
         endobj
         """
         file_entry = DecodedStreamObject()
-        file_entry.setData(data)
+        file_entry.set_data(data)
         file_entry.update({NameObject(PA.TYPE): NameObject("/EmbeddedFile")})
 
         # The Filespec entry

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -1629,14 +1629,6 @@ class PdfWriter:
     ]
 
     def _get_page_layout(self) -> Optional[LayoutType]:
-        """
-        Get the page layout.
-
-        See :meth:`setPageLayout()<PdfWriter.setPageLayout>` for a description of valid layouts.
-
-        :return: Page layout currently being used.
-        :rtype: str, None if not specified
-        """
         try:
             return cast(LayoutType, self._root_object["/PageLayout"])
         except KeyError:
@@ -1771,14 +1763,6 @@ class PdfWriter:
     ]
 
     def _get_page_mode(self) -> Optional[PagemodeType]:
-        """
-        Get the page mode.
-        See :meth:`setPageMode()<PdfWriter.setPageMode>` for a description
-        of valid modes.
-
-        :return: Page mode currently being used.
-        :rtype: str, None if not specified.
-        """
         try:
             return cast(PagemodeType, self._root_object["/PageMode"])
         except KeyError:

--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -502,7 +502,7 @@ def _xobj_to_image(x_object_obj: Dict[str, Any]) -> Tuple[Optional[str], bytes]:
     from PIL import Image
 
     size = (x_object_obj[IA.WIDTH], x_object_obj[IA.HEIGHT])
-    data = x_object_obj.getData()  # type: ignore
+    data = x_object_obj.get_data()  # type: ignore
     if x_object_obj[IA.COLOR_SPACE] == ColorSpaces.DEVICE_RGB:
         mode: Literal["RGB", "P"] = "RGB"
     else:
@@ -513,7 +513,7 @@ def _xobj_to_image(x_object_obj: Dict[str, Any]) -> Tuple[Optional[str], bytes]:
             extension = ".png"
             img = Image.frombytes(mode, size, data)
             if G.S_MASK in x_object_obj:  # add alpha channel
-                alpha = Image.frombytes("L", size, x_object_obj[G.S_MASK].getData())
+                alpha = Image.frombytes("L", size, x_object_obj[G.S_MASK].get_data())
                 img.putalpha(alpha)
             img_byte_arr = BytesIO()
             img.save(img_byte_arr, format="PNG")

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1120,11 +1120,27 @@ class StreamObject(DictionaryObject):
 
 
 class DecodedStreamObject(StreamObject):
+    def get_data(self) -> Any:
+        return self._data
+
+    def set_data(self, data) -> Any:
+        self._data = data
+
     def getData(self) -> Any:
+        warnings.warn(
+            DEPR_MSG.format("decodedSelf", "decoded_self"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         return self._data
 
     def setData(self, data: Any) -> None:
-        self._data = data
+        warnings.warn(
+            DEPR_MSG.format("decodedSelf", "decoded_self"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.set_data(data)
 
 
 class EncodedStreamObject(StreamObject):
@@ -1149,12 +1165,12 @@ class EncodedStreamObject(StreamObject):
         )
         self.decoded_self = value
 
-    def getData(self) -> Union[None, str, bytes]:
+    def get_data(self) -> Union[None, str, bytes]:
         from .filters import decodeStreamData
 
         if self.decoded_self:
             # cached version of decoded object
-            return self.decoded_self.getData()
+            return self.decoded_self.get_data()
         else:
             # create decoded object
             decoded = DecodedStreamObject()
@@ -1166,7 +1182,7 @@ class EncodedStreamObject(StreamObject):
             self.decoded_self = decoded
             return decoded._data
 
-    def setData(self, data: Any) -> None:
+    def set_data(self, data: Any) -> None:
         raise PdfReadError("Creating EncodedStreamObject is not currently supported")
 
 
@@ -1185,10 +1201,10 @@ class ContentStream(DecodedStreamObject):
         if isinstance(stream, ArrayObject):
             data = b_("")
             for s in stream:
-                data += b_(s.get_object().getData())
+                data += b_(s.get_object().get_data())
             stream = BytesIO(b_(data))
         else:
-            stream = BytesIO(b_(stream.getData()))
+            stream = BytesIO(b_(stream.get_data()))
         self.__parseContentStream(stream)
 
     def __parseContentStream(self, stream: StreamType) -> None:

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1630,11 +1630,25 @@ class Field(TreeObject):
                 pass
 
     # TABLE 8.69 Entries common to all field dictionaries
+    @property
+    def field_type(self) -> Optional[NameObject]:
+        """Read-only property accessing the type of this field."""
+        return self.get("/FT")
 
     @property
     def fieldType(self) -> Optional[NameObject]:
-        """Read-only property accessing the type of this field."""
-        return self.get("/FT")
+        """
+        .. deprecated:: 1.28.3
+
+            Use :py:attr:`field_type` instead.
+        """
+        warnings.warn(
+            "fieldType will be removed in PyPDF2 2.0.0. "
+            "Use the field_type property instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.field_type
 
     @property
     def parent(self) -> Optional[DictionaryObject]:
@@ -1652,18 +1666,48 @@ class Field(TreeObject):
         return self.get("/T")
 
     @property
-    def altName(self) -> Optional[str]:
+    def alternate_name(self) -> Optional[str]:
         """Read-only property accessing the alternate name of this field."""
         return self.get("/TU")
 
     @property
-    def mappingName(self) -> Optional[str]:
+    def altName(self) -> Optional[str]:
+        """
+        .. deprecated:: 1.28.3
+
+            Use :py:attr:`alternate_name` instead.
+        """
+        warnings.warn(
+            "altName will be removed in PyPDF2 2.0.0. "
+            "Use the alternate_name property instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.alternate_name
+
+    @property
+    def mapping_name(self) -> Optional[str]:
         """
         Read-only property accessing the mapping name of this field. This
         name is used by PyPDF2 as a key in the dictionary returned by
         :meth:`get_fields()<PyPDF2.PdfReader.get_fields>`
         """
         return self.get("/TM")
+
+    @property
+    def mappingName(self) -> Optional[str]:
+        """
+        .. deprecated:: 1.28.3
+
+            Use :py:attr:`mapping_name` instead.
+        """
+        warnings.warn(
+            "mappingName will be removed in PyPDF2 2.0.0. "
+            "Use the mapping_name property instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.mapping_name
 
     @property
     def flags(self) -> Optional[int]:
@@ -1682,18 +1726,48 @@ class Field(TreeObject):
         return self.get("/V")
 
     @property
-    def defaultValue(self) -> Optional[Any]:
+    def default_value(self) -> Optional[Any]:
         """Read-only property accessing the default value of this field."""
         return self.get("/DV")
 
     @property
-    def additionalActions(self) -> Optional[DictionaryObject]:
+    def defaultValue(self) -> Optional[Any]:
+        """
+        .. deprecated:: 1.28.3
+
+            Use :py:attr:`default_value` instead.
+        """
+        warnings.warn(
+            "defaultValue will be removed in PyPDF2 2.0.0. "
+            "Use the default_value property instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.default_value
+
+    @property
+    def additional_actions(self) -> Optional[DictionaryObject]:
         """
         Read-only property accessing the additional actions dictionary.
         This dictionary defines the field's behavior in response to trigger events.
         See Section 8.5.2 of the PDF 1.7 reference.
         """
         return self.get("/AA")
+
+    @property
+    def additionalActions(self) -> Optional[DictionaryObject]:
+        """
+        .. deprecated:: 1.28.3
+
+            Use :py:attr:`additional_actions` instead.
+        """
+        warnings.warn(
+            "additionalActions will be removed in PyPDF2 2.0.0. "
+            "Use the additional_actions property instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.additional_actions
 
 
 class Destination(TreeObject):

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1606,7 +1606,7 @@ class RectangleObject(ArrayObject):
 class Field(TreeObject):
     """
     A class representing a field dictionary. This class is accessed through
-    :meth:`getFields()<PyPDF2.PdfReader.getFields>`
+    :meth:`get_fields()<PyPDF2.PdfReader.get_fields>`
     """
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -1661,7 +1661,7 @@ class Field(TreeObject):
         """
         Read-only property accessing the mapping name of this field. This
         name is used by PyPDF2 as a key in the dictionary returned by
-        :meth:`getFields()<PyPDF2.PdfReader.getFields>`
+        :meth:`get_fields()<PyPDF2.PdfReader.get_fields>`
         """
         return self.get("/TM")
 
@@ -1764,7 +1764,8 @@ class Destination(TreeObject):
         else:
             raise PdfReadError("Unknown Destination Type: %r" % typ)
 
-    def getDestArray(self) -> ArrayObject:
+    @property
+    def dest_array(self) -> ArrayObject:
         return ArrayObject(
             [self.raw_get("/Page"), self["/Type"]]
             + [
@@ -1774,6 +1775,20 @@ class Destination(TreeObject):
             ]
         )
 
+    def getDestArray(self) -> ArrayObject:
+        """
+        .. deprecated:: 1.28.3
+
+            Use :py:attr:`dest_array` instead.
+        """
+        warnings.warn(
+            "getDestArray will be removed in PyPDF2 2.0.0. "
+            "Use the dest_array property instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.dest_array
+
     def write_to_stream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
@@ -1781,7 +1796,7 @@ class Destination(TreeObject):
         key = NameObject("/D")
         key.write_to_stream(stream, encryption_key)
         stream.write(b_(" "))
-        value = self.getDestArray()
+        value = self.dest_array
         value.write_to_stream(stream, encryption_key)
 
         key = NameObject("/S")
@@ -1884,7 +1899,7 @@ class Bookmark(Destination):
         key = NameObject("/Dest")
         key.write_to_stream(stream, encryption_key)
         stream.write(b_(" "))
-        value = self.getDestArray()
+        value = self.dest_array
         value.write_to_stream(stream, encryption_key)
         stream.write(b_("\n"))
         stream.write(b_(">>"))

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1074,6 +1074,14 @@ class StreamObject(DictionaryObject):
         return retval
 
     def flateEncode(self) -> "EncodedStreamObject":
+        warnings.warn(
+            DEPR_MSG.format("flateEncode", "flate_encode"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.flate_encode()
+
+    def flate_encode(self) -> "EncodedStreamObject":
         from .filters import FlateDecode
 
         if SA.FILTER in self:

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1036,7 +1036,7 @@ class StreamObject(DictionaryObject):
         self.decoded_self: Optional[DecodedStreamObject] = None
 
     @property
-    def decodedSelf(self):
+    def decodedSelf(self) -> Optional["DecodedStreamObject"]:
         warnings.warn(
             DEPR_MSG.format("decodedSelf", "decoded_self"),
             PendingDeprecationWarning,
@@ -1123,7 +1123,7 @@ class DecodedStreamObject(StreamObject):
     def get_data(self) -> Any:
         return self._data
 
-    def set_data(self, data) -> Any:
+    def set_data(self, data: Any) -> Any:
         self._data = data
 
     def getData(self) -> Any:
@@ -1148,7 +1148,7 @@ class EncodedStreamObject(StreamObject):
         self.decoded_self: Optional[DecodedStreamObject] = None
 
     @property
-    def decodedSelf(self):
+    def decodedSelf(self) -> Optional["DecodedStreamObject"]:
         warnings.warn(
             DEPR_MSG.format("decodedSelf", "decoded_self"),
             PendingDeprecationWarning,

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -910,6 +910,9 @@ class TreeObject(DictionaryObject):
             child = child["/Next"]  # type: ignore
 
     def addChild(self, child: Any, pdf: Any) -> None:  # PdfReader
+        self.add_child(child, pdf)
+
+    def add_child(self, child: Any, pdf: Any) -> None:  # PdfReader
         child_obj = child.get_object()
         child = pdf.get_reference(child_obj)
         assert isinstance(child, IndirectObject)
@@ -935,6 +938,14 @@ class TreeObject(DictionaryObject):
         child_obj[NameObject("/Parent")] = parent_ref
 
     def removeChild(self, child: Any) -> None:
+        warnings.warn(
+            DEPR_MSG.format("removeChild", "remove_child"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.remove_child(child)
+
+    def remove_child(self, child: Any) -> None:
         child_obj = child.get_object()
 
         if NameObject("/Parent") not in child_obj:
@@ -1312,12 +1323,20 @@ class RectangleObject(ArrayObject):
         # must have four points
         assert len(arr) == 4
         # automatically convert arr[x] into NumberObject(arr[x]) if necessary
-        ArrayObject.__init__(self, [self.ensureIsNumber(x) for x in arr])  # type: ignore
+        ArrayObject.__init__(self, [self._ensure_is_number(x) for x in arr])  # type: ignore
 
-    def ensureIsNumber(self, value: Any) -> Union[FloatObject, NumberObject]:
+    def _ensure_is_number(self, value: Any) -> Union[FloatObject, NumberObject]:
         if not isinstance(value, (NumberObject, FloatObject)):
             value = FloatObject(value)
         return value
+
+    def ensureIsNumber(self, value: Any) -> Union[FloatObject, NumberObject]:
+        warnings.warn(
+            "ensureIsNumber will be removed in PyPDF2 2.0.0. ",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self._ensure_is_number(value)
 
     def __repr__(self) -> str:
         return "RectangleObject(%s)" % repr(list(self))
@@ -1412,7 +1431,7 @@ class RectangleObject(ArrayObject):
 
     @lower_left.setter
     def lower_left(self, value: List[Any]) -> None:
-        self[0], self[1] = (self.ensureIsNumber(x) for x in value)
+        self[0], self[1] = (self._ensure_is_number(x) for x in value)
 
     @property
     def lower_right(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
@@ -1424,7 +1443,7 @@ class RectangleObject(ArrayObject):
 
     @lower_right.setter
     def lower_right(self, value: List[Any]) -> None:
-        self[2], self[1] = (self.ensureIsNumber(x) for x in value)
+        self[2], self[1] = (self._ensure_is_number(x) for x in value)
 
     @property
     def upper_left(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
@@ -1436,7 +1455,7 @@ class RectangleObject(ArrayObject):
 
     @upper_left.setter
     def upper_left(self, value: List[Any]) -> None:
-        self[0], self[3] = (self.ensureIsNumber(x) for x in value)
+        self[0], self[3] = (self._ensure_is_number(x) for x in value)
 
     @property
     def upper_right(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
@@ -1448,7 +1467,7 @@ class RectangleObject(ArrayObject):
 
     @upper_right.setter
     def upper_right(self, value: List[Any]) -> None:
-        self[2], self[3] = (self.ensureIsNumber(x) for x in value)
+        self[2], self[3] = (self._ensure_is_number(x) for x in value)
 
     def getLowerLeft(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
         warnings.warn(
@@ -1496,7 +1515,7 @@ class RectangleObject(ArrayObject):
             PendingDeprecationWarning,
             stacklevel=2,
         )
-        self[2], self[1] = (self.ensureIsNumber(x) for x in value)
+        self[2], self[1] = (self._ensure_is_number(x) for x in value)
 
     def setUpperLeft(self, value: Tuple[float, float]) -> None:
         warnings.warn(
@@ -1504,7 +1523,7 @@ class RectangleObject(ArrayObject):
             PendingDeprecationWarning,
             stacklevel=2,
         )
-        self[0], self[3] = (self.ensureIsNumber(x) for x in value)
+        self[0], self[3] = (self._ensure_is_number(x) for x in value)
 
     def setUpperRight(self, value: Tuple[float, float]) -> None:
         warnings.warn(
@@ -1512,7 +1531,7 @@ class RectangleObject(ArrayObject):
             PendingDeprecationWarning,
             stacklevel=2,
         )
-        self[2], self[3] = (self.ensureIsNumber(x) for x in value)
+        self[2], self[3] = (self._ensure_is_number(x) for x in value)
 
     @property
     def width(self) -> decimal.Decimal:

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1033,7 +1033,25 @@ class TreeObject(DictionaryObject):
 class StreamObject(DictionaryObject):
     def __init__(self) -> None:
         self.__data: Optional[str] = None
-        self.decodedSelf: Optional[DecodedStreamObject] = None
+        self.decoded_self: Optional[DecodedStreamObject] = None
+
+    @property
+    def decodedSelf(self):
+        warnings.warn(
+            DEPR_MSG.format("decodedSelf", "decoded_self"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.decoded_self
+
+    @decodedSelf.setter
+    def decodedSelf(self, value: "DecodedStreamObject") -> None:
+        warnings.warn(
+            DEPR_MSG.format("decodedSelf", "decoded_self"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.decoded_self = value
 
     @property
     def _data(self) -> Any:
@@ -1111,14 +1129,32 @@ class DecodedStreamObject(StreamObject):
 
 class EncodedStreamObject(StreamObject):
     def __init__(self) -> None:
-        self.decodedSelf: Optional[DecodedStreamObject] = None
+        self.decoded_self: Optional[DecodedStreamObject] = None
+
+    @property
+    def decodedSelf(self):
+        warnings.warn(
+            DEPR_MSG.format("decodedSelf", "decoded_self"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.decoded_self
+
+    @decodedSelf.setter
+    def decodedSelf(self, value: DecodedStreamObject) -> None:
+        warnings.warn(
+            DEPR_MSG.format("decodedSelf", "decoded_self"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.decoded_self = value
 
     def getData(self) -> Union[None, str, bytes]:
         from .filters import decodeStreamData
 
-        if self.decodedSelf:
+        if self.decoded_self:
             # cached version of decoded object
-            return self.decodedSelf.getData()
+            return self.decoded_self.getData()
         else:
             # create decoded object
             decoded = DecodedStreamObject()
@@ -1127,7 +1163,7 @@ class EncodedStreamObject(StreamObject):
             for key, value in list(self.items()):
                 if key not in (SA.LENGTH, SA.FILTER, SA.DECODE_PARMS):
                     decoded[key] = value
-            self.decodedSelf = decoded
+            self.decoded_self = decoded
             return decoded._data
 
     def setData(self, data: Any) -> None:

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -676,7 +676,8 @@ class DictionaryObject(dict, PdfObject):
     def __getitem__(self, key: Any) -> PdfObject:
         return dict.__getitem__(self, key).get_object()
 
-    def getXmpMetadata(self) -> Optional[PdfObject]:  # XmpInformation
+    @property
+    def xmp_metadata(self) -> Optional[PdfObject]:
         """
         Retrieve XMP (Extensible Metadata Platform) data relevant to the
         this object, if available.
@@ -698,15 +699,33 @@ class DictionaryObject(dict, PdfObject):
             self[NameObject("/Metadata")] = metadata
         return metadata
 
+    def getXmpMetadata(self) -> Optional[PdfObject]:  # XmpInformation
+        """
+        .. deprecated:: 1.28.3
+
+            Use :meth:`xmp_metadata` instead.
+        """
+        warnings.warn(
+            "getXmpMetadata will be removed in PyPDF2 2.0.0. "
+            "Use xmp_metadata instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.xmp_metadata
+
     @property
     def xmpMetadata(self) -> Optional[PdfObject]:  # XmpInformation
         """
-        Read-only property that accesses the {@link
-        #DictionaryObject.getXmpData getXmpData} function.
-        <p>
-        Stability: Added in v1.12, will exist for all future v1.x releases.
+        .. deprecated:: 1.28.3
+
+            Use :meth:`xmp_metadata` instead.
         """
-        return self.getXmpMetadata()
+        warnings.warn(
+            "xmpMetadata will be removed in PyPDF2 2.0.0. Use xmp_metadata instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.xmp_metadata
 
     def write_to_stream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -186,7 +186,7 @@ def _getter_single(
 class XmpInformation(PdfObject):
     """
     An object that represents Adobe XMP metadata.
-    Usually accessed by :meth:`getXmpMetadata()<PyPDF2.PdfReader.getXmpMetadata>`
+    Usually accessed by :py:attr:`xmp_metadata()<PyPDF2.PdfReader.xmp_metadata>`
     """
 
     def __init__(self, stream: ContentStream) -> None:
@@ -255,6 +255,8 @@ class XmpInformation(PdfObject):
         """
         warnings.warn(
             DEPR_MSG.format("getNodesInNamespace", "get_nodes_in_namespace"),
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self.get_nodes_in_namespace(aboutUri, namespace)
 

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -98,7 +98,7 @@ def _getter_bag(namespace: str, name: str) -> Optional[Any]:
         if cached:
             return cached
         retval = []
-        for element in self.getElement("", namespace, name):
+        for element in self.get_element("", namespace, name):
             bags = element.getElementsByTagNameNS(RDF_NAMESPACE, "Bag")
             if len(bags):
                 for bag in bags:
@@ -233,6 +233,8 @@ class XmpInformation(PdfObject):
         """
         warnings.warn(
             DEPR_MSG.format("getElement", "get_element"),
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self.get_element(aboutUri, namespace, name)
 

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -191,7 +191,7 @@ class XmpInformation(PdfObject):
 
     def __init__(self, stream: ContentStream) -> None:
         self.stream = stream
-        doc_root: Document = parseString(self.stream.getData())
+        doc_root: Document = parseString(self.stream.get_data())
         self.rdfRoot: XmlElement = doc_root.getElementsByTagNameNS(
             RDF_NAMESPACE, "RDF"
         )[0]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install PyPDF2
 from PyPDF2 import PdfReader
 
 reader = PdfReader("example.pdf")
-number_of_pages = reader.numPages
+number_of_pages = len(reader.pages)
 page = reader.pages[0]
 text = page.extract_text()
 ```

--- a/docs/modules/DocumentInformation.rst
+++ b/docs/modules/DocumentInformation.rst
@@ -1,7 +1,7 @@
 The DocumentInformation Class
 -----------------------------
 
-.. autoclass:: PyPDF2.generic.DocumentInformation
+.. autoclass:: PyPDF2._reader.DocumentInformation
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/user/adding-pdf-annotations.md
+++ b/docs/user/adding-pdf-annotations.md
@@ -6,7 +6,7 @@
 from PyPDF2 import PdfWriter
 
 writer = PdfWriter()
-writer.addBlankPage(width=200, height=200)
+writer.add_blank_page(width=200, height=200)
 
 data = b"any bytes - typically read from a file"
 writer.add_attachment("smile.png", data)

--- a/docs/user/cropping-and-transforming.md
+++ b/docs/user/cropping-and-transforming.md
@@ -50,7 +50,7 @@ page_base.merge_page(page_box)
 
 # Write the result back
 writer = PdfWriter()
-writer.addPage(page_base)
+writer.add_page(page_base)
 with open("merged-foo.pdf", "wb") as fp:
     writer.write(fp)
 ```
@@ -76,7 +76,7 @@ page_base.merge_page(page_box)
 
 # Write the result back
 writer = PdfWriter()
-writer.addPage(page_base)
+writer.add_page(page_base)
 with open("merged-foo.pdf", "wb") as fp:
     writer.write(fp)
 ```

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -30,8 +30,8 @@ reader = PyPDF2.PdfReader("example.pdf")
 writer = PyPDF2.PdfWriter()
 
 for page in reader.pages:
-    page.compressContentStreams()
-    writer.addPage(page)
+    page.compress_content_streams()
+    writer.add_page(page)
 
 with open("out.pdf", "wb") as f:
     writer.write(f)

--- a/docs/user/forms.md
+++ b/docs/user/forms.md
@@ -6,7 +6,7 @@
 from PyPDF2 import PdfReader
 
 reader = PdfReader("form.pdf")
-fields = reader.getFormTextFields()
+fields = reader.get_form_text_fields()
 fields == {"key": "value", "key2": "value2"}
 ```
 

--- a/docs/user/forms.md
+++ b/docs/user/forms.md
@@ -23,7 +23,9 @@ fields = reader.get_fields()
 
 writer.add_page(page)
 
-writer.updatePageFormFieldValues(writer.pages[0], {"fieldname": "some filled in text"})
+writer.update_page_form_field_values(
+    writer.pages[0], {"fieldname": "some filled in text"}
+)
 
 # write "output" to PyPDF2-output.pdf
 with open("filled-out.pdf", "wb") as output_stream:

--- a/docs/user/reading-pdf-annotations.md
+++ b/docs/user/reading-pdf-annotations.md
@@ -63,5 +63,5 @@ for page in reader.pages:
             subtype = annot.get_object()["/Subtype"]
             if subtype == "/FileAttachment":
                 fileobj = annotobj["/FS"]
-                attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].getData()
+                attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].get_data()
 ```

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -25,7 +25,7 @@ def page_ops(pdf_path, password):
     page.scale(2, 2)
     page.scale_by(0.5)
     page.scale_to(100, 100)
-    page.compressContentStreams()
+    page.compress_content_streams()
     page.extract_text()
 
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -53,9 +53,9 @@ def merge():
     file_merger.append(pdf_forms)
 
     # Merging an encrypted file
-    pdfr = PyPDF2.PdfReader(pdf_pw)
-    pdfr.decrypt("openpassword")
-    file_merger.append(pdfr)
+    reader = PyPDF2.PdfReader(pdf_pw)
+    reader.decrypt("openpassword")
+    file_merger.append(reader)
 
     # PdfReader object:
     file_merger.append(PyPDF2.PdfReader(pdf_path, "rb"), bookmark=True)
@@ -76,8 +76,10 @@ def merge():
     file_merger.close()
 
     # Check if bookmarks are correct
-    pdfr = PyPDF2.PdfReader(tmp_path)
-    assert [el.title for el in pdfr.get_outlines() if isinstance(el, Destination)] == [
+    reader = PyPDF2.PdfReader(tmp_path)
+    assert [
+        el.title for el in reader._get_outlines() if isinstance(el, Destination)
+    ] == [
         "A bookmark",
         "Foo",
         "Bar",

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -20,7 +20,7 @@ def page_ops(pdf_path, password):
     page = reader.pages[0]
     page.mergeRotatedScaledPage(page, 90, 1, 1)
     page.mergeScaledTranslatedPage(page, 1, 1, 1)
-    page.merge_rotated_scaled_translated_page(page, 90, 1, 1, 1, 1)
+    page.mergeRotatedScaledTranslatedPage(page, 90, 1, 1, 1, 1)
     page.add_transformation((1, 0, 0, 0, 0, 0))
     page.scale(2, 2)
     page.scale_by(0.5)

--- a/tests/test_basic_features.py
+++ b/tests/test_basic_features.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from PyPDF2 import PdfReader, PdfWriter
 
 TESTS_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -21,7 +23,9 @@ def test_basic_features():
     writer.add_page(reader.pages[0].rotate_clockwise(90))
 
     # add page 3 from input1, rotated the other way:
-    writer.add_page(reader.pages[0].rotateCounterClockwise(90))
+    with pytest.warns(PendingDeprecationWarning):
+        rotated = reader.pages[0].rotateCounterClockwise(90)
+    writer.add_page(rotated)
     # alt: output.addPage(input1.pages[0].rotate_clockwise(270))
 
     # add page 4 from input1, but first add a watermark from another PDF:

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -235,7 +235,9 @@ def test_DictionaryObject_key_is_no_pdfobject():
 
 def test_DictionaryObject_xmp_meta():
     do = DictionaryObject({NameObject("/S"): NameObject("/GoTo")})
-    assert do.xmpMetadata is None
+    assert do.xmp_metadata is None
+    with pytest.warns(PendingDeprecationWarning):
+        assert do.xmpMetadata is None
 
 
 def test_DictionaryObject_value_is_no_pdfobject():

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -17,40 +17,42 @@ def test_merge():
     pdf_forms = os.path.join(RESOURCE_ROOT, "pdflatex-forms.pdf")
     pdf_pw = os.path.join(RESOURCE_ROOT, "libreoffice-writer-password.pdf")
 
-    file_merger = PyPDF2.PdfMerger()
+    merger = PyPDF2.PdfMerger()
 
     # string path:
-    file_merger.append(pdf_path)
-    file_merger.append(outline)
-    file_merger.append(pdf_path, pages=PyPDF2.pagerange.PageRange(slice(0, 0)))
-    file_merger.append(pdf_forms)
+    merger.append(pdf_path)
+    merger.append(outline)
+    merger.append(pdf_path, pages=PyPDF2.pagerange.PageRange(slice(0, 0)))
+    merger.append(pdf_forms)
 
     # Merging an encrypted file
-    pdfr = PyPDF2.PdfReader(pdf_pw)
-    pdfr.decrypt("openpassword")
-    file_merger.append(pdfr)
+    reader = PyPDF2.PdfReader(pdf_pw)
+    reader.decrypt("openpassword")
+    merger.append(reader)
 
     # PdfReader object:
-    file_merger.append(PyPDF2.PdfReader(pdf_path), bookmark="foo")
+    merger.append(PyPDF2.PdfReader(pdf_path), bookmark="foo")
 
     # File handle
     with open(pdf_path, "rb") as fh:
-        file_merger.append(fh)
+        merger.append(fh)
 
-    bookmark = file_merger.add_bookmark("A bookmark", 0)
-    file_merger.add_bookmark("deeper", 0, parent=bookmark)
-    file_merger.add_metadata({"author": "Martin Thoma"})
-    file_merger.add_named_destination("title", 0)
-    file_merger.set_page_layout("/SinglePage")
-    file_merger.set_page_mode("/UseThumbs")
+    bookmark = merger.add_bookmark("A bookmark", 0)
+    merger.add_bookmark("deeper", 0, parent=bookmark)
+    merger.add_metadata({"author": "Martin Thoma"})
+    merger.add_named_destination("title", 0)
+    merger.set_page_layout("/SinglePage")
+    merger.set_page_mode("/UseThumbs")
 
     tmp_path = "dont_commit_merged.pdf"
-    file_merger.write(tmp_path)
-    file_merger.close()
+    merger.write(tmp_path)
+    merger.close()
 
     # Check if bookmarks are correct
-    pdfr = PyPDF2.PdfReader(tmp_path)
-    assert [el.title for el in pdfr.get_outlines() if isinstance(el, Destination)] == [
+    reader = PyPDF2.PdfReader(tmp_path)
+    assert [
+        el.title for el in reader._get_outlines() if isinstance(el, Destination)
+    ] == [
         "A bookmark",
         "Foo",
         "Bar",

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -70,11 +70,11 @@ def test_page_operations(pdf_path, password):
     page.merge_rotated_scaled_translated_page(
         page, 90, scale=1, tx=1, ty=1, expand=True
     )
-    page.add_transformation([1, 0, 0, 0, 0, 0])
+    page.add_transformation((1, 0, 0, 0, 0, 0))
     page.scale(2, 2)
     page.scaleBy(0.5)
     page.scaleTo(100, 100)
-    page.compressContentStreams()
+    page.compress_content_streams()
     page.extractText()
 
 
@@ -153,7 +153,7 @@ def test_compress_content_streams(pdf_path, password):
     if password:
         reader.decrypt(password)
     for page in reader.pages:
-        page.compressContentStreams()
+        page.compress_content_streams()
 
 
 def test_page_properties():

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -67,15 +67,22 @@ def test_page_operations(pdf_path, password):
         reader.decrypt(password)
 
     page: PageObject = reader.pages[0]
-    page.merge_rotated_scaled_translated_page(
-        page, 90, scale=1, tx=1, ty=1, expand=True
-    )
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeRotatedScaledTranslatedPage(
+            page, 90, scale=1, tx=1, ty=1, expand=True
+        )
     page.add_transformation((1, 0, 0, 0, 0, 0))
     page.scale(2, 2)
-    page.scaleBy(0.5)
-    page.scaleTo(100, 100)
+    page.scale_by(0.5)
+    page.scale_to(100, 100)
     page.compress_content_streams()
-    page.extractText()
+    page.extract_text()
+    with pytest.warns(PendingDeprecationWarning):
+        page.scaleBy(0.5)
+    with pytest.warns(PendingDeprecationWarning):
+        page.scaleTo(100, 100)
+    with pytest.warns(PendingDeprecationWarning):
+        page.extractText()
 
 
 def test_transformation_equivalence():
@@ -98,7 +105,8 @@ def test_transformation_equivalence():
     # Option 2: The old way
     page_box2 = deepcopy(page_box)
     page_base2 = deepcopy(page_base)
-    page_base2.mergeTransformedPage(page_box2, op, expand=False)
+    with pytest.warns(PendingDeprecationWarning):
+        page_base2.mergeTransformedPage(page_box2, op, expand=False)
 
     # Should be the smae
     assert page_base1[NameObject(PG.CONTENTS)] == page_base2[NameObject(PG.CONTENTS)]
@@ -124,16 +132,23 @@ def test_page_transformations():
     reader = PdfReader(pdf_path)
 
     page: PageObject = reader.pages[0]
-    page.mergeRotatedPage(page, 90, expand=True)
-    page.mergeRotatedScaledPage(page, 90, 1, expand=True)
-    page.merge_rotated_scaled_translated_page(
-        page, 90, scale=1, tx=1, ty=1, expand=True
-    )
-    page.mergeRotatedTranslatedPage(page, 90, 100, 100, expand=False)
-    page.mergeScaledPage(page, 2, expand=False)
-    page.mergeScaledTranslatedPage(page, 1, 1, 1)
-    page.mergeTranslatedPage(page, 100, 100, expand=False)
-    page.add_transformation([1, 0, 0, 0, 0, 0])
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeRotatedPage(page, 90, expand=True)
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeRotatedScaledPage(page, 90, 1, expand=True)
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeRotatedScaledTranslatedPage(
+            page, 90, scale=1, tx=1, ty=1, expand=True
+        )
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeRotatedTranslatedPage(page, 90, 100, 100, expand=False)
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeScaledPage(page, 2, expand=False)
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeScaledTranslatedPage(page, 1, 1, 1)
+    with pytest.warns(PendingDeprecationWarning):
+        page.mergeTranslatedPage(page, 100, 100, expand=False)
+    page.add_transformation((1, 0, 0, 0, 0, 0))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -129,7 +129,7 @@ def test_get_attachments(src):
 )
 def test_get_outlines(src, outline_elements):
     reader = PdfReader(src)
-    outlines = reader.get_outlines()
+    outlines = reader._get_outlines()
     assert len(outlines) == outline_elements
 
 
@@ -494,7 +494,7 @@ def test_read_encrypted_without_decryption():
 def test_get_destination_page_number():
     src = os.path.join(RESOURCE_ROOT, "pdflatex-outline.pdf")
     reader = PdfReader(src)
-    outlines = reader.get_outlines()
+    outlines = reader._get_outlines()
     for outline in outlines:
         if not isinstance(outline, list):
             reader.get_destination_page_number(outline)
@@ -551,13 +551,13 @@ def test_issue604(strict):
         if strict:
             with pytest.raises(PdfReadError) as exc:
                 pdf = PdfReader(f, strict=strict)
-                bookmarks = pdf.get_outlines()
+                bookmarks = pdf._get_outlines()
             if "Unknown Destination" not in exc.value.args[0]:
                 raise Exception("Expected exception not raised")
             return  # bookmarks not correct
         else:
             pdf = PdfReader(f, strict=strict)
-            bookmarks = pdf.get_outlines()
+            bookmarks = pdf._get_outlines()
 
         def getDestPages(x):
             # print(x)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -301,16 +301,16 @@ def test_get_form(src, expected, expected_get_fields):
         for field in fields.values():
             # Just access the attributes
             [
-                field.fieldType,
+                field.field_type,
                 field.parent,
                 field.kids,
                 field.name,
-                field.altName,
-                field.mappingName,
+                field.alternate_name,
+                field.mapping_name,
                 field.flags,
                 field.value,
-                field.defaultValue,
-                field.additionalActions,
+                field.default_value,
+                field.additional_actions,
             ]
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -335,7 +335,7 @@ def test_get_page_number(src, page_nb):
 def test_get_page_layout(src, expected):
     src = os.path.join(RESOURCE_ROOT, src)
     reader = PdfReader(src)
-    assert reader.getPageLayout() == expected
+    assert reader.page_layout == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -607,7 +607,7 @@ def test_VirtualList():
 
 
 def test_convert_to_int():
-    assert convert_to_int(b'\x01', 8) == 1
+    assert convert_to_int(b"\x01", 8) == 1
 
 
 def test_convert_to_int_error():
@@ -617,5 +617,8 @@ def test_convert_to_int_error():
 
 
 def test_convertToInt_deprecated():
-    with pytest.warns(PendingDeprecationWarning, match="convertToInt will be removed with PyPDF2 2.0.0. Use convert_to_int instead."):
-        assert convertToInt(b'\x01', 8) == 1
+    with pytest.warns(
+        PendingDeprecationWarning,
+        match="convertToInt will be removed with PyPDF2 2.0.0. Use convert_to_int instead.",
+    ):
+        assert convertToInt(b"\x01", 8) == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -117,7 +117,7 @@ def test_get_attachments(src):
                 annotobj = annotation.get_object()
                 if annotobj[IA.SUBTYPE] == "/FileAttachment":
                     fileobj = annotobj["/FS"]
-                    attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].getData()
+                    attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].get_data()
     return attachments
 
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -57,7 +57,7 @@ def test_PdfReaderJpegImage():
 
         page = reader.pages[0]
         x_object = page[PG.RESOURCES]["/XObject"].get_object()
-        data = x_object["/Im4"].getData()
+        data = x_object["/Im4"].get_data()
 
         # Compare the text of the PDF to a known source
         assert binascii.hexlify(data).decode() == imagetext, (

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -90,7 +90,8 @@ def test_rotate(degree):
     with open(os.path.join(RESOURCE_ROOT, "crazyones.pdf"), "rb") as inputfile:
         reader = PdfReader(inputfile)
         page = reader.pages[0]
-        page.rotateCounterClockwise(degree)
+        with pytest.warns(PendingDeprecationWarning):
+            page.rotateCounterClockwise(degree)
 
 
 def test_rotate_45():
@@ -98,5 +99,6 @@ def test_rotate_45():
         reader = PdfReader(inputfile)
         page = reader.pages[0]
         with pytest.raises(ValueError) as exc:
-            page.rotateCounterClockwise(45)
+            with pytest.warns(PendingDeprecationWarning):
+                page.rotateCounterClockwise(45)
         assert exc.value.args[0] == "Rotation angle must be a multiple of 90"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -354,10 +354,10 @@ def test_regression_issue670():
     filepath = os.path.join(RESOURCE_ROOT, "crazyones.pdf")
     reader = PdfReader(filepath, strict=False)
     for _ in range(2):
-        pdf_writer = PdfWriter()
-        pdf_writer.add_page(reader.pages[0])
+        writer = PdfWriter()
+        writer.add_page(reader.pages[0])
         with open("dont_commit_issue670.pdf", "wb") as f_pdf:
-            pdf_writer.write(f_pdf)
+            writer.write(f_pdf)
 
 
 def test_issue301():
@@ -365,8 +365,8 @@ def test_issue301():
     Test with invalid stream length object
     """
     with open(os.path.join(RESOURCE_ROOT, "issue-301.pdf"), "rb") as f:
-        r = PdfReader(f)
-        w = PdfWriter()
-        w.append_pages_from_reader(r)
+        reader = PdfReader(f)
+        writer = PdfWriter()
+        writer.append_pages_from_reader(reader)
         o = BytesIO()
-        w.write(o)
+        writer.write(o)

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -19,7 +19,7 @@ RESOURCE_ROOT = os.path.join(PROJECT_ROOT, "resources")
 )
 def test_read_xmp(src, has_xmp):
     reader = PdfReader(src)
-    xmp = reader.xmpMetadata
+    xmp = reader.xmp_metadata
     assert (xmp is None) == (not has_xmp)
     if has_xmp:
         for el in xmp.getElement(

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -22,8 +22,8 @@ def test_read_xmp(src, has_xmp):
     xmp = reader.xmp_metadata
     assert (xmp is None) == (not has_xmp)
     if has_xmp:
-        for el in xmp.getElement(
-            aboutUri="", namespace=PyPDF2.xmp.RDF_NAMESPACE, name="Artist"
+        for el in xmp.get_element(
+            about_uri="", namespace=PyPDF2.xmp.RDF_NAMESPACE, name="Artist"
         ):
             print(f"el={el}")
 
@@ -33,9 +33,10 @@ def test_read_xmp(src, has_xmp):
 
 def get_all_tiff(xmp):
     data = {}
-    tiff_ns = xmp.getNodesInNamespace(
-        aboutUri="", namespace="http://ns.adobe.com/tiff/1.0/"
-    )
+    with pytest.warns(PendingDeprecationWarning):
+        tiff_ns = xmp.getNodesInNamespace(
+            aboutUri="", namespace="http://ns.adobe.com/tiff/1.0/"
+        )
     for tag in tiff_ns:
         contents = []
         for content in tag.childNodes:


### PR DESCRIPTION
PyPDF2 interface changes:

* getXmpMetadata / xmpMetadata ➔ xmp_metadata
* get_outlines ➔ _get_outlines (use outlines property instead)
* getXmpMetadata ➔ xmp_metadata
* getDestArray ➔ dest_array
* additionalActions ➔ additional_actions
* defaultValue ➔ default_value
* mappingName ➔ mapping_name
* altName ➔ alternate_name
* fieldType ➔ field_type
* ensureIsNumber ➔ _ensure_is_number
* decodedSelf : decoded_self
* addChild / removeChild  ➔ add_child / remove_child
* flateEncode  ➔ flate_encode
* getData / setData  ➔ get_data / set_data

DOC: Use the new PyPDF2 interface
STY: Use reader/writer as variable names for PdfReader / PdfWriter