### PR TITLE
TST: Remove -OO testrun from CI

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.10.1", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout Code
@@ -47,11 +47,6 @@ jobs:
     - name: Test with pytest
       run: |
         python -m coverage run --parallel-mode -m pytest tests -vv
-      if: matrix.python-version != '3.10.1'
-    - name: Test with pytest (OO flag)
-      run: |
-        python -OO -m coverage run --parallel-mode -m pytest tests -vv
-      if: matrix.python-version == '3.10.1'
     - name: Test with mypy
       run : |
         mypy PyPDF2 --show-error-codes --disallow-untyped-defs --disallow-incomplete-defs


### PR DESCRIPTION
We needed it because we were manipulating a docstring programmatically.
As long as we don't rely on assert / docstrings being present, we don't
need to test with -OO.