### PR TITLE
DEP: PEP8 renaming

### DIFF
--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -923,7 +923,7 @@ class PageObject(DictionaryObject):
         if content is not None:
             if not isinstance(content, ContentStream):
                 content = ContentStream(content, self.pdf)
-            self[NameObject(PG.CONTENTS)] = content.flateEncode()
+            self[NameObject(PG.CONTENTS)] = content.flate_encode()
 
     def compressContentStreams(self):
         """

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -389,7 +389,7 @@ class PdfReader(object):
         """
         try:
             self._override_encryption = True
-            return self.trailer[TK.ROOT].getXmpMetadata()
+            return self.trailer[TK.ROOT].xmp_metadata
         finally:
             self._override_encryption = False
 
@@ -729,9 +729,9 @@ class PdfReader(object):
     @property
     def outlines(self):
         """Read-only property."""
-        return self.get_outlines()
+        return self._get_outlines()
 
-    def get_outlines(self, node=None, outlines=None):
+    def _get_outlines(self, node=None, outlines=None):
         """
         Retrieve the document outline present in the document.
 
@@ -768,7 +768,7 @@ class PdfReader(object):
             # check for sub-outlines
             if "/First" in node:
                 sub_outlines = []
-                self.get_outlines(node["/First"], sub_outlines)
+                self._get_outlines(node["/First"], sub_outlines)
                 if sub_outlines:
                     outlines.append(sub_outlines)
 
@@ -778,18 +778,33 @@ class PdfReader(object):
 
         return outlines
 
+    def get_outlines(self, node=None, outlines=None):
+        """
+        .. deprecated:: 1.28.0
+
+            Use the property :py:attr:`outlines` instead.
+        """
+        warnings.warn(
+            "get_outlines will be removed in PyPDF2 2.0.0. "
+            "Use the property :py:attr:`outlines` instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self._get_outlines(node, outlines)
+
     def getOutlines(self, node=None, outlines=None):
         """
         .. deprecated:: 1.28.0
 
-            Use :meth:`get_outlines` instead.
+            Use the property :py:attr:`outlines` instead.
         """
         warnings.warn(
-            "getOutlines will be removed in PyPDF2 2.0.0. Use get_outlines instead.",
+            "getOutlines will be removed in PyPDF2 2.0.0. "
+            "Use the property 'outlines' instead.",
             PendingDeprecationWarning,
             stacklevel=2,
         )
-        return self.get_outlines(node, outlines)
+        return self._get_outlines(node, outlines)
 
     def _get_page_number_by_indirect(self, indirect_ref):
         """Generate _pageId2Num"""
@@ -1073,7 +1088,7 @@ class PdfReader(object):
         assert obj_stm["/Type"] == "/ObjStm"
         # /N is the number of indirect objects in the stream
         assert idx < obj_stm["/N"]
-        stream_data = BytesIO(b_(obj_stm.getData()))
+        stream_data = BytesIO(b_(obj_stm.get_data()))
         for i in range(obj_stm["/N"]):
             readNonWhitespace(stream_data)
             stream_data.seek(-1, 1)
@@ -1515,7 +1530,7 @@ class PdfReader(object):
         xrefstream = read_object(stream, self)
         assert xrefstream["/Type"] == "/XRef"
         self.cache_indirect_object(generation, idnum, xrefstream)
-        stream_data = BytesIO(b_(xrefstream.getData()))
+        stream_data = BytesIO(b_(xrefstream.get_data()))
         # Index pairs specify the subsections in the dictionary. If
         # none create one subsection that spans everything.
         idx_pairs = xrefstream.get("/Index", [0, xrefstream.get("/Size")])

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -966,7 +966,7 @@ class PdfWriter(object):
             parent = outline_ref
 
         parent = parent.get_object()
-        parent.addChild(dest_ref, self)
+        parent.add_child(dest_ref, self)
 
         return dest_ref
 
@@ -1002,7 +1002,7 @@ class PdfWriter(object):
             parent = outline_ref
 
         parent = parent.get_object()
-        parent.addChild(bookmark_ref, self)
+        parent.add_child(bookmark_ref, self)
 
         return bookmark_ref
 
@@ -1053,7 +1053,7 @@ class PdfWriter(object):
         dest = Destination(
             NameObject("/" + title + " bookmark"), page_ref, NameObject(fit), *zoom_args
         )
-        dest_array = dest.getDestArray()
+        dest_array = dest.dest_array
         action.update(
             {NameObject("/D"): dest_array, NameObject("/S"): NameObject("/GoTo")}
         )
@@ -1089,7 +1089,7 @@ class PdfWriter(object):
         bookmark_ref = self._add_object(bookmark)
 
         parent = parent.get_object()
-        parent.addChild(bookmark_ref, self)
+        parent.add_child(bookmark_ref, self)
 
         return bookmark_ref
 
@@ -1470,7 +1470,7 @@ class PdfWriter(object):
         dest = Destination(
             NameObject("/LinkName"), page_dest, NameObject(fit), *zoom_args
         )  # TODO: create a better name for the link
-        dest_array = dest.getDestArray()
+        dest_array = dest.dest_array
 
         lnk = DictionaryObject()
         lnk.update(

--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -553,7 +553,7 @@ def _xobj_to_image(x_object_obj):
     from PyPDF2.constants import GraphicsStateParameters as G
 
     size = (x_object_obj[IA.WIDTH], x_object_obj[IA.HEIGHT])
-    data = x_object_obj.getData()
+    data = x_object_obj.get_data()
     if x_object_obj[IA.COLOR_SPACE] == ColorSpaces.DEVICE_RGB:
         mode = "RGB"
     else:
@@ -564,7 +564,7 @@ def _xobj_to_image(x_object_obj):
             extension = ".png"
             img = Image.frombytes(mode, size, data)
             if G.S_MASK in x_object_obj:  # add alpha channel
-                alpha = Image.frombytes("L", size, x_object_obj[G.S_MASK].getData())
+                alpha = Image.frombytes("L", size, x_object_obj[G.S_MASK].get_data())
                 img.putalpha(alpha)
             img_byte_arr = io.BytesIO()
             img.save(img_byte_arr, format="PNG")

--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -29,7 +29,7 @@ import warnings
 from sys import version_info
 
 from PyPDF2._reader import PdfReader
-from PyPDF2._utils import _isString, DEPR_MSG, str_
+from PyPDF2._utils import DEPR_MSG, _isString, str_
 from PyPDF2._writer import PdfWriter
 from PyPDF2.constants import PagesAttributes as PA
 from PyPDF2.generic import *
@@ -177,7 +177,7 @@ class PdfMerger(object):
 
         outline = []
         if import_bookmarks:
-            outline = reader.get_outlines()
+            outline = reader.outlines
             outline = self._trim_outline(reader, outline, pages)
 
         if bookmark:
@@ -272,7 +272,7 @@ class PdfMerger(object):
         usage.
         """
         self.pages = []
-        for fo, _pdfr, mine in self.inputs:
+        for fo, _reader, mine in self.inputs:
             if mine:
                 fo.close()
 
@@ -639,7 +639,7 @@ class PdfMerger(object):
         dest = Destination(
             NameObject("/" + title + " bookmark"), page_ref, NameObject(fit), *zoom_args
         )
-        dest_array = dest.getDestArray()
+        dest_array = dest.dest_array
         action.update(
             {NameObject("/D"): dest_array, NameObject("/S"): NameObject("/GoTo")}
         )
@@ -674,7 +674,7 @@ class PdfMerger(object):
 
         bookmark_ref = self.output._add_object(bookmark)
         parent = parent.get_object()
-        parent.addChild(bookmark_ref, self.output)
+        parent.add_child(bookmark_ref, self.output)
 
         return bookmark_ref
 
@@ -747,7 +747,7 @@ class OutlinesObject(list):
 
         self.pdf._addObject(bookmark)
 
-        self.tree.addChild(bookmark)
+        self.tree.add_child(bookmark)
 
     def removeAll(self):
         for child in self.tree.children():

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -58,12 +58,12 @@ iso8601 = re.compile(
 class XmpInformation(PdfObject):
     """
     An object that represents Adobe XMP metadata.
-    Usually accessed by :meth:`getXmpMetadata()<PyPDF2.PdfReader.getXmpMetadata>`
+    Usually accessed by :py:attr:`xmp_metadata()<PyPDF2.PdfReader.xmp_metadata>`
     """
 
     def __init__(self, stream):
         self.stream = stream
-        doc_root = parseString(self.stream.getData())
+        doc_root = parseString(self.stream.get_data())
         self.rdfRoot = doc_root.getElementsByTagNameNS(RDF_NAMESPACE, "RDF")[0]
         self.cache = {}
 
@@ -100,6 +100,8 @@ class XmpInformation(PdfObject):
         """
         warnings.warn(
             DEPR_MSG.format("getElement", "get_element"),
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self.get_element(aboutUri, namespace, name)
 
@@ -122,6 +124,8 @@ class XmpInformation(PdfObject):
         """
         warnings.warn(
             DEPR_MSG.format("getNodesInNamespace", "get_nodes_in_namespace"),
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self.get_nodes_in_namespace(aboutUri, namespace)
 
@@ -166,7 +170,7 @@ class XmpInformation(PdfObject):
             if cached:
                 return cached
             retval = []
-            for element in self.getElement("", namespace, name):
+            for element in self.get_element("", namespace, name):
                 bags = element.getElementsByTagNameNS(RDF_NAMESPACE, "Bag")
                 if len(bags):
                     for bag in bags:

--- a/Tests/bench.py
+++ b/Tests/bench.py
@@ -25,7 +25,7 @@ def page_ops(pdf_path, password):
     page.scale(2, 2)
     page.scaleBy(0.5)
     page.scaleTo(100, 100)
-    page.compressContentStreams()
+    page.compress_content_streams()
     page.extract_text()
 
 
@@ -44,40 +44,42 @@ def merge():
     pdf_forms = os.path.join(RESOURCE_ROOT, "pdflatex-forms.pdf")
     pdf_pw = os.path.join(RESOURCE_ROOT, "libreoffice-writer-password.pdf")
 
-    file_merger = PyPDF2.PdfMerger()
+    merger = PyPDF2.PdfMerger()
 
     # string path:
-    file_merger.append(pdf_path)
-    file_merger.append(outline)
-    file_merger.append(pdf_path, pages=PyPDF2.pagerange.PageRange(slice(0, 0)))
-    file_merger.append(pdf_forms)
+    merger.append(pdf_path)
+    merger.append(outline)
+    merger.append(pdf_path, pages=PyPDF2.pagerange.PageRange(slice(0, 0)))
+    merger.append(pdf_forms)
 
     # Merging an encrypted file
-    pdfr = PyPDF2.PdfReader(pdf_pw)
-    pdfr.decrypt("openpassword")
-    file_merger.append(pdfr)
+    reader = PyPDF2.PdfReader(pdf_pw)
+    reader.decrypt("openpassword")
+    merger.append(reader)
 
     # PdfReader object:
-    file_merger.append(PyPDF2.PdfReader(pdf_path, "rb"), bookmark=True)
+    merger.append(PyPDF2.PdfReader(pdf_path, "rb"), bookmark=True)
 
     # File handle
     with open(pdf_path, "rb") as fh:
-        file_merger.append(fh)
+        merger.append(fh)
 
-    bookmark = file_merger.add_bookmark("A bookmark", 0)
-    file_merger.add_bookmark("deeper", 0, parent=bookmark)
-    file_merger.add_metadata({"author": "Martin Thoma"})
-    file_merger.add_named_destionation("title", 0)
-    file_merger.set_page_layout("/SinglePage")
-    file_merger.set_page_mode("/UseThumbs")
+    bookmark = merger.add_bookmark("A bookmark", 0)
+    merger.add_bookmark("deeper", 0, parent=bookmark)
+    merger.add_metadata({"author": "Martin Thoma"})
+    merger.add_named_destionation("title", 0)
+    merger.set_page_layout("/SinglePage")
+    merger.set_page_mode("/UseThumbs")
 
     tmp_path = "dont_commit_merged.pdf"
-    file_merger.write(tmp_path)
-    file_merger.close()
+    merger.write(tmp_path)
+    merger.close()
 
     # Check if bookmarks are correct
-    pdfr = PyPDF2.PdfReader(tmp_path)
-    assert [el.title for el in pdfr.get_outlines() if isinstance(el, Destination)] == [
+    reader = PyPDF2.PdfReader(tmp_path)
+    assert [
+        el.title for el in reader._get_outlines() if isinstance(el, Destination)
+    ] == [
         "A bookmark",
         "Foo",
         "Bar",

--- a/Tests/test_generic.py
+++ b/Tests/test_generic.py
@@ -220,7 +220,7 @@ def test_DictionaryObject_key_is_no_pdfobject():
 
 def test_DictionaryObject_xmp_meta():
     do = DictionaryObject({NameObject("/S"): NameObject("/GoTo")})
-    assert do.xmpMetadata is None
+    assert do.xmp_metadata is None
 
 
 def test_DictionaryObject_value_is_no_pdfobject():

--- a/Tests/test_merger.py
+++ b/Tests/test_merger.py
@@ -17,40 +17,42 @@ def test_merge():
     pdf_forms = os.path.join(RESOURCE_ROOT, "pdflatex-forms.pdf")
     pdf_pw = os.path.join(RESOURCE_ROOT, "libreoffice-writer-password.pdf")
 
-    file_merger = PyPDF2.PdfMerger()
+    merger = PyPDF2.PdfMerger()
 
     # string path:
-    file_merger.append(pdf_path)
-    file_merger.append(outline)
-    file_merger.append(pdf_path, pages=PyPDF2.pagerange.PageRange(slice(0, 0)))
-    file_merger.append(pdf_forms)
+    merger.append(pdf_path)
+    merger.append(outline)
+    merger.append(pdf_path, pages=PyPDF2.pagerange.PageRange(slice(0, 0)))
+    merger.append(pdf_forms)
 
     # Merging an encrypted file
-    pdfr = PyPDF2.PdfReader(pdf_pw)
-    pdfr.decrypt("openpassword")
-    file_merger.append(pdfr)
+    reader = PyPDF2.PdfReader(pdf_pw)
+    reader.decrypt("openpassword")
+    merger.append(reader)
 
     # PdfReader object:
-    file_merger.append(PyPDF2.PdfReader(pdf_path, "rb"), bookmark=True)
+    merger.append(PyPDF2.PdfReader(pdf_path, "rb"), bookmark=True)
 
     # File handle
     with open(pdf_path, "rb") as fh:
-        file_merger.append(fh)
+        merger.append(fh)
 
-    bookmark = file_merger.add_bookmark("A bookmark", 0)
-    file_merger.add_bookmark("deeper", 0, parent=bookmark)
-    file_merger.add_metadata({"author": "Martin Thoma"})
-    file_merger.add_named_destionation("title", 0)
-    file_merger.set_page_layout("/SinglePage")
-    file_merger.set_page_mode("/UseThumbs")
+    bookmark = merger.add_bookmark("A bookmark", 0)
+    merger.add_bookmark("deeper", 0, parent=bookmark)
+    merger.add_metadata({"author": "Martin Thoma"})
+    merger.add_named_destionation("title", 0)
+    merger.set_page_layout("/SinglePage")
+    merger.set_page_mode("/UseThumbs")
 
     tmp_path = "dont_commit_merged.pdf"
-    file_merger.write(tmp_path)
-    file_merger.close()
+    merger.write(tmp_path)
+    merger.close()
 
     # Check if bookmarks are correct
-    pdfr = PyPDF2.PdfReader(tmp_path)
-    assert [el.title for el in pdfr.get_outlines() if isinstance(el, Destination)] == [
+    reader = PyPDF2.PdfReader(tmp_path)
+    assert [
+        el.title for el in reader._get_outlines() if isinstance(el, Destination)
+    ] == [
         "A bookmark",
         "Foo",
         "Bar",

--- a/Tests/test_page.py
+++ b/Tests/test_page.py
@@ -71,7 +71,7 @@ def test_page_operations(pdf_path, password):
     page.scale(2, 2)
     page.scaleBy(0.5)
     page.scaleTo(100, 100)
-    page.compressContentStreams()
+    page.compress_content_streams()
     page.extract_text()
 
 
@@ -92,7 +92,7 @@ def test_compress_content_streams(pdf_path, password):
     if password:
         reader.decrypt(password)
     for page in reader.pages:
-        page.compressContentStreams()
+        page.compress_content_streams()
 
 
 def test_page_properties():

--- a/Tests/test_reader.py
+++ b/Tests/test_reader.py
@@ -125,7 +125,7 @@ def test_get_attachments(src):
                 annotobj = annotation.get_object()
                 if annotobj[IA.SUBTYPE] == "/FileAttachment":
                     fileobj = annotobj["/FS"]
-                    attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].getData()
+                    attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].get_data()
     return attachments
 
 
@@ -138,7 +138,7 @@ def test_get_attachments(src):
 )
 def test_get_outlines(src, outline_elements):
     reader = PdfReader(src)
-    outlines = reader.get_outlines()
+    outlines = reader._get_outlines()
     assert len(outlines) == outline_elements
 
 
@@ -310,16 +310,16 @@ def test_get_form(src, expected, expected_get_fields):
         for field in fields.values():
             # Just access the attributes
             [
-                field.fieldType,
+                field.field_type,
                 field.parent,
                 field.kids,
                 field.name,
                 field.altName,
-                field.mappingName,
+                field.mapping_name,
                 field.flags,
                 field.value,
-                field.defaultValue,
-                field.additionalActions,
+                field.default_value,
+                field.additional_actions,
             ]
 
 
@@ -505,7 +505,7 @@ def test_read_encrypted_without_decryption():
 def test_get_destination_age_number():
     src = os.path.join(RESOURCE_ROOT, "pdflatex-outline.pdf")
     reader = PdfReader(src)
-    outlines = reader.get_outlines()
+    outlines = reader._get_outlines()
     for outline in outlines:
         if not isinstance(outline, list):
             reader.get_destination_page_number(outline)
@@ -562,13 +562,13 @@ def test_issue604(strict):
         if strict:
             with pytest.raises(PdfReadError) as exc:
                 pdf = PdfReader(f, strict=strict)
-                bookmarks = pdf.get_outlines()
+                bookmarks = pdf._get_outlines()
             if "Unknown Destination" not in exc.value.args[0]:
                 raise Exception("Expected exception not raised")
             return  # bookmarks not correct
         else:
             pdf = PdfReader(f, strict=strict)
-            bookmarks = pdf.get_outlines()
+            bookmarks = pdf._get_outlines()
 
         def getDestPages(x):
             # print(x)

--- a/Tests/test_workflows.py
+++ b/Tests/test_workflows.py
@@ -59,7 +59,7 @@ def test_PdfReaderJpegImage():
 
         page = reader._get_page(0)
         x_object = page[PG.RESOURCES]["/XObject"].get_object()
-        data = x_object["/Im4"].getData()
+        data = x_object["/Im4"].get_data()
 
         # Compare the text of the PDF to a known source
         assert binascii.hexlify(data).decode() == imagetext, (

--- a/docs/user/cropping-and-transforming.md
+++ b/docs/user/cropping-and-transforming.md
@@ -49,7 +49,7 @@ page_box = reader.pages[0]
 page_base.mergeTransformedPage(page_box, Transformation())
 # Write the result back
 writer = PdfWriter()
-writer.addPage(page_base)
+writer.add_page(page_base)
 with open("merged-foo.pdf", "wb") as fp:
     writer.write(fp)
 ```
@@ -71,7 +71,7 @@ op = Transformation().rotate(45)
 page_base.mergeTransformedPage(page_box, op)
 # Write the result back
 writer = PdfWriter()
-writer.addPage(page_base)
+writer.add_page(page_base)
 with open("merged-foo.pdf", "wb") as fp:
     writer.write(fp)
 ```

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -30,8 +30,8 @@ reader = PyPDF2.PdfReader("example.pdf")
 writer = PyPDF2.PdfWriter()
 
 for page in reader.pages:
-    page.compressContentStreams()
-    writer.addPage(page)
+    page.compress_content_streams()
+    writer.add_page(page)
 
 with open("out.pdf", "wb") as f:
     writer.write(f)

--- a/docs/user/reading-pdf-annotations.md
+++ b/docs/user/reading-pdf-annotations.md
@@ -63,5 +63,5 @@ for page in reader.pages:
             subtype = annot.get_object()["/Subtype"]
             if subtype == "/FileAttachment":
                 fileobj = annotobj["/FS"]
-                attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].getData()
+                attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].get_data()
 ```


### PR DESCRIPTION
PdfReader: 
* getXmpMetadata / xmpMetadata ➔ xmp_metadata
* get_outlines ➔ _get_outlines (use outlines property instead)

Field attributes:
* additionalActions ➔ additional_actions
* defaultValue ➔ default_value
* mappingName ➔ mapping_name
* altName ➔ alternate_name
* fieldType ➔ field_type

StreamObject: 
* decodedSelf : decoded_self
* flateEncode  ➔ flate_encode

Other:

* Destination: getDestArray ➔ dest_array
* RectangleObject: ensureIsNumber ➔ _ensure_is_number
* TreeObject: addChild / removeChild  ➔ add_child / remove_child
* DecodedStreamObject: getData / setData  ➔ get_data / set_data

See https://github.com/py-pdf/PyPDF2/pull/900