### PR TITLE
BUG: Fix error adding transformation to page without /Contents

### DIFF
--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -896,6 +896,7 @@ class PageObject(DictionaryObject):
         if content is not None:
             content = PageObject._add_transformation_matrix(content, self.pdf, ctm)
             content = PageObject._push_pop_gs(content, self.pdf)
+            self[NameObject(PG.CONTENTS)] = content
         # if expanding the page to fit a new page, calculate the new media box size
         if expand:
             corners = [
@@ -929,7 +930,6 @@ class PageObject(DictionaryObject):
 
             self.mediabox.lower_left = lowerleft
             self.mediabox.upper_right = upperright
-        self[NameObject(PG.CONTENTS)] = content
 
     def addTransformation(self, ctm: CompressedTransformationMatrix) -> None:
         """

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -200,3 +200,8 @@ def test_page_scale():
 
     assert op.scale(sx=2).ctm == (2, 0, 0, 2, 0, 0)
     assert op.scale(sy=3).ctm == (3, 0, 0, 3, 0, 0)
+
+
+def test_add_transformation_on_page_without_contents():
+    page = PageObject()
+    page.add_transformation(Transformation())


### PR DESCRIPTION
PR fixes a bug where calling `pageObject.add_transformation()` on a page that doesn't have the optional `/Contents` value would cause an error to be raised:

```
>>> pageObject.add_transformation(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mpeveler/github/PyPDF2/PyPDF2/_page.py", line 932, in add_transformation
    self[NameObject(PG.CONTENTS)] = content
  File "/home/mpeveler/github/PyPDF2/PyPDF2/generic.py", line 666, in __setitem__
    raise ValueError("value must be PdfObject")
ValueError: value must be PdfObject
```

The fix here is to only try to update the `/Contents` attribute only if we actually have an updated contents value, which ignores the case where `/Contents` does not exist.