### PR TITLE
DOC: Adjust deprecation messages

### DIFF
--- a/PyPDF2/__init__.py
+++ b/PyPDF2/__init__.py
@@ -1,4 +1,4 @@
-from ._merger import PdfMerger
+from ._merger import PdfFileMerger, PdfMerger
 from ._page import Transformation
 from ._reader import DocumentInformation, PdfFileReader, PdfReader
 from ._version import __version__
@@ -12,9 +12,9 @@ __all__ = [
     "PaperSize",
     "DocumentInformation",
     "parse_filename_page_ranges",
-    "PdfFileMerger",  # will be removed soon; use PdfMerger instead
-    "PdfFileReader",  # will be removed soon; use PdfReader instead
-    "PdfFileWriter",  # will be removed soon; use PdfWriter instead
+    "PdfFileMerger",  # will be removed in PyPDF2 3.0.0; use PdfMerger instead
+    "PdfFileReader",  # will be removed in PyPDF2 3.0.0; use PdfReader instead
+    "PdfFileWriter",  # will be removed in PyPDF2 3.0.0; use PdfWriter instead
     "PdfMerger",
     "Transformation",
     "PdfReader",

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -636,8 +636,10 @@ class PageObject(DictionaryObject):
             Use :meth:`add_transformation`  and :meth:`merge_page` instead.
         """
         warnings.warn(
-            "page.mergeTransformedPage(page2, ctm) will be removed in PyPDF 2.0.0. "
-            "Use page2.add_transformation(ctm); page.merge_page(page2) instead.",
+            DEPR_MSG.format(
+                "page.mergeTransformedPage(page2, ctm)",
+                "page2.add_transformation(ctm); page.merge_page(page2)",
+            ),
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -47,6 +47,8 @@ from typing import (
 from ._page import PageObject, _VirtualList
 from ._security import RC4_encrypt, _alg33_1, _alg34, _alg35
 from ._utils import (
+    DEPR_MSG,
+    DEPR_MSG_NO_REPLACEMENT,
     StrByteType,
     StreamType,
     b_,
@@ -102,8 +104,7 @@ def convert_to_int(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
 
 def convertToInt(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
     warnings.warn(
-        "convertToInt will be removed with PyPDF2 2.0.0. "
-        "Use convert_to_int instead.",
+        DEPR_MSG.format("convertToInt", "convert_to_int"),
         PendingDeprecationWarning,
         stacklevel=2,
     )
@@ -142,7 +143,7 @@ class DocumentInformation(DictionaryObject):
             Use the attributes (e.g. :py:attr:`title` / :py:attr:`author`).
         """
         warnings.warn(
-            "getText will be removed in PyPDF2 2.0.0.",
+            DEPR_MSG_NO_REPLACEMENT.format("getText"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -281,7 +282,7 @@ class PdfReader:
         """
         warnings.warn(
             "The `getDocumentInfo` method of PdfReader will be replaced by the "
-            "`metadata` attribute in PyPDF2 2.0.0. You can switch to the "
+            "`metadata` attribute in PyPDF2 3.0.0. You can switch to the "
             "metadata attribute already.",
             PendingDeprecationWarning,
             stacklevel=2,
@@ -297,7 +298,7 @@ class PdfReader:
         """
         warnings.warn(
             "The `documentInfo` attribute of PdfReader will be replaced by "
-            "`metadata` in PyPDF2 2.0.0. You can switch to the metadata "
+            "`metadata` in PyPDF2 3.0.0. You can switch to the metadata "
             "attribute already.",
             PendingDeprecationWarning,
             stacklevel=2,
@@ -328,7 +329,7 @@ class PdfReader:
         """
         warnings.warn(
             "The `getXmpMetadata` method of PdfReader will be replaced by the "
-            "`xmp_metadata` attribute in PyPDF2 2.0.0. You can switch to the "
+            "`xmp_metadata` attribute in PyPDF2 3.0.0. You can switch to the "
             "xmp_metadata attribute already.",
             PendingDeprecationWarning,
             stacklevel=2,
@@ -344,7 +345,7 @@ class PdfReader:
         """
         warnings.warn(
             "The `xmpMetadata` attribute of PdfReader will be replaced by the "
-            "`xmp_metadata` attribute in PyPDF2 2.0.0. You can switch to the "
+            "`xmp_metadata` attribute in PyPDF2 3.0.0. You can switch to the "
             "xmp_metadata attribute already.",
             PendingDeprecationWarning,
             stacklevel=2,
@@ -385,8 +386,7 @@ class PdfReader:
             Use :code:`len(reader.pages)` instead.
         """
         warnings.warn(
-            "The `getNumPages` method of PdfReader will be removed in PyPDF2 2.0.0. "
-            "Use `len(reader.pages)` instead.",
+            DEPR_MSG.format("reader.getNumPages", "len(reader.pages)"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -400,7 +400,7 @@ class PdfReader:
             Use :code:`len(reader.pages)` instead.
         """
         warnings.warn(
-            "The `numPages` attribute of PdfReader will be removed in PyPDF2 2.0.0. "
+            "The `numPages` attribute of PdfReader will be removed in PyPDF2 3.0.0. "
             "Use `len(reader.pages)` instead.",
             PendingDeprecationWarning,
             stacklevel=2,
@@ -414,8 +414,7 @@ class PdfReader:
             Use :code:`reader.pages[pageNumber]` instead.
         """
         warnings.warn(
-            "`getPage` of PdfReader will be removed in PyPDF2 2.0.0. "
-            "Use `reader.pages[pageNumber]` instead.",
+            DEPR_MSG.format("reader.getPage(pageNumber)", "reader.pages[pageNumber]"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -445,8 +444,7 @@ class PdfReader:
             Use :py:attr:`named_destinations` instead.
         """
         warnings.warn(
-            "namedDestinations will be removed in PyPDF2 2.0.0. "
-            "Use `named_destinations` instead.",
+            DEPR_MSG.format("reader.namedDestinations", "reader.named_destinations"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -528,8 +526,7 @@ class PdfReader:
             Use :meth:`get_fields` instead.
         """
         warnings.warn(
-            "The getFields method of PdfReader will be removed in PyPDF2 2.0.0. "
-            "Use the get_fields() method instead.",
+            DEPR_MSG.format("reader.getFields", "reader.get_fields"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -611,8 +608,7 @@ class PdfReader:
             Use :meth:`get_form_text_fields` instead.
         """
         warnings.warn(
-            "The getFormTextFields method of PdfReader will be removed in PyPDF2 2.0.0. "
-            "Use the get_form_text_fields() method instead.",
+            DEPR_MSG.format("reader.getFormTextFields", "reader.get_form_text_fields"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -675,8 +671,7 @@ class PdfReader:
             Use :py:attr:`named_destinations` instead.
         """
         warnings.warn(
-            "getNamedDestinations will be removed in PyPDF2 2.0.0. "
-            "Use the named_destinations property instead.",
+            DEPR_MSG.format("reader.getNamedDestinations", "reader.named_destinations"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -744,7 +739,7 @@ class PdfReader:
             Use :py:attr:`outlines` instead.
         """
         warnings.warn(
-            "getOutlines will be removed in PyPDF2 2.0.0. Use the outlines attribute instead.",
+            DEPR_MSG.format("reader.getOutlines", "reader.outlines"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -788,8 +783,9 @@ class PdfReader:
             Use :meth:`get_page_number` instead.
         """
         warnings.warn(
-            "getPageNumber will be removed in PyPDF2 2.0.0. "
-            "Use get_page_number instead.",
+            DEPR_MSG.format(
+                "reader.getPageNumber(page)", "reader.get_page_number(page)"
+            ),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -812,8 +808,9 @@ class PdfReader:
             Use :meth:`get_destination_page_number` instead.
         """
         warnings.warn(
-            "getDestinationPageNumber will be removed in PyPDF2 2.0.0. "
-            "Use get_destination_page_number instead.",
+            DEPR_MSG.format(
+                "reader.getDestinationPageNumber", "reader.get_destination_page_number"
+            ),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -909,8 +906,7 @@ class PdfReader:
             Use :py:attr:`page_layout` instead.
         """
         warnings.warn(
-            "getPageLayout will be removed in PyPDF2 2.0.0. "
-            "Use the attribute 'page_layout' instead.",
+            DEPR_MSG.format("reader.getPageLayout()", "reader.page_layout"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -924,8 +920,7 @@ class PdfReader:
             Use :py:attr:`page_layout` instead.
         """
         warnings.warn(
-            "pageLayout will be removed in PyPDF2 2.0.0. "
-            "Use the attribute 'page_layout' instead.",
+            DEPR_MSG.format("reader.pageLayout", "reader.page_layout"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -967,8 +962,7 @@ class PdfReader:
             Use :py:attr:`page_mode` instead.
         """
         warnings.warn(
-            "getPageMode will be removed in PyPDF2 2.0.0. "
-            "Use the attribute 'page_mode' instead.",
+            DEPR_MSG.format("reader.getPageMode()", "reader.page_mode"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -982,8 +976,7 @@ class PdfReader:
             Use :py:attr:`page_mode` instead.
         """
         warnings.warn(
-            "pageMode will be removed in PyPDF2 2.0.0. "
-            "Use the attribute 'page_mode' instead.",
+            DEPR_MSG.format("reader.pageMode", "reader.page_mode"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1163,8 +1156,10 @@ class PdfReader:
             Use :meth:`get_object` instead.
         """
         warnings.warn(
-            "getObject(indirectReference) will be removed in PyPDF2 2.0.0. "
-            "Use get_object(indirect_reference) instead.",
+            DEPR_MSG.format(
+                "reader.getObject(indirectReference)",
+                "reader.get_object(indirect_reference)",
+            ),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1235,8 +1230,7 @@ class PdfReader:
             Use :meth:`read_object_header` instead.
         """
         warnings.warn(
-            "readObjectHeader will be removed with PyPDF2 2.0.0. "
-            "Use read_object_header instead.",
+            DEPR_MSG.format("reader.readObjectHeader", "reader.read_object_header"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1256,8 +1250,9 @@ class PdfReader:
             Use :meth:`cache_get_indirect_object` instead.
         """
         warnings.warn(
-            "cacheGetIndirectObject will be removed with PyPDF2 2.0.0. "
-            "Use cache_get_indirect_object instead.",
+            DEPR_MSG.format(
+                "reader.cacheGetIndirectObject", "reader.cache_get_indirect_object"
+            ),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1284,8 +1279,9 @@ class PdfReader:
             Use :meth:`cache_indirect_object` instead.
         """
         warnings.warn(
-            "cacheIndirectObject will be removed with PyPDF2 2.0.0. "
-            "Use cache_indirect_object instead.",
+            DEPR_MSG.format(
+                "reader.cacheIndirectObject", "reader.cache_indirect_object"
+            ),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1679,8 +1675,7 @@ class PdfReader:
             Use :meth:`read_next_end_line` instead.
         """
         warnings.warn(
-            "readNextEndLine will be removed in PyPDF2 2.0.0. "
-            "Use read_next_end_line instead.",
+            DEPR_MSG.format("reader.readNextEndLine", "reader.read_next_end_line"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1833,8 +1828,7 @@ class PdfReader:
             Use :py:attr:`is_encrypted` instead.
         """
         warnings.warn(
-            "getIsEncrypted() will be removed in PyPDF2 2.0.0. "
-            "Use the is_encrypted property instead.",
+            DEPR_MSG.format("reader.getIsEncrypted()", "reader.is_encrypted"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1848,8 +1842,7 @@ class PdfReader:
             Use :py:attr:`is_encrypted` instead.
         """
         warnings.warn(
-            "isEncrypted will be removed in PyPDF2 2.0.0. "
-            "Use the is_encrypted property instead.",
+            DEPR_MSG.format("reader.isEncrypted", "reader.is_encrypted"),
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/PyPDF2/_utils.py
+++ b/PyPDF2/_utils.py
@@ -54,8 +54,8 @@ bytes_type = type(bytes())  # Works the same in Python 2.X and 3.X
 StreamType = Union[BytesIO, BufferedReader, BufferedWriter, FileIO]
 StrByteType = Union[str, StreamType]
 
-DEPR_MSG_NO_REPLACEMENT = "{} is deprecated and will be removed in PyPDF2 2.0.0."
-DEPR_MSG = "{} is deprecated and will be removed in PyPDF2 2.0.0. Use {} instead."
+DEPR_MSG_NO_REPLACEMENT = "{} is deprecated and will be removed in PyPDF2 3.0.0."
+DEPR_MSG = "{} is deprecated and will be removed in PyPDF2 3.0.0. Use {} instead."
 
 
 def read_until_whitespace(stream: StreamType, maxchars: Optional[int] = None) -> bytes:

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -1641,8 +1641,7 @@ class PdfWriter:
             Use :py:attr:`page_layout` instead.
         """
         warnings.warn(
-            "getPageLayout() will be removed in PyPDF2 2.0.0. "
-            "Use the page_layout attribute instead.",
+            DEPR_MSG.format("writer.getPageLayout", "writer.page_layout"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1687,8 +1686,7 @@ class PdfWriter:
             Use :py:attr:`page_layout` instead.
         """
         warnings.warn(
-            "setPageLayout() will be removed in PyPDF2 2.0.0. "
-            "Use the page_layout attribute instead.",
+            DEPR_MSG.format("writer.setPageLayout(val)", "writer.page_layout = val"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1731,8 +1729,7 @@ class PdfWriter:
             Use :py:attr:`page_layout` instead.
         """
         warnings.warn(
-            "pageLayout will be removed in PyPDF2 2.0.0. "
-            "Use the page_layout attribute instead.",
+            DEPR_MSG.format("writer.pageLayout", "writer.page_layout"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1746,8 +1743,7 @@ class PdfWriter:
             Use :py:attr:`page_layout` instead.
         """
         warnings.warn(
-            "pageLayout will be removed in PyPDF2 2.0.0. "
-            "Use the page_layout attribute instead.",
+            DEPR_MSG.format("writer.pageLayout", "writer.page_layout"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1775,8 +1771,7 @@ class PdfWriter:
             Use :py:attr:`page_mode` instead.
         """
         warnings.warn(
-            "getPageMode() will be removed in PyPDF2 2.0.0. "
-            "Use the page_mode attribute instead.",
+            DEPR_MSG.format("writer.getPageMode()", "writer.page_mode"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1805,8 +1800,7 @@ class PdfWriter:
             Use :py:attr:`page_mode` instead.
         """
         warnings.warn(
-            "setPageMode() will be removed in PyPDF2 2.0.0. "
-            "Use the page_mode attribute instead.",
+            DEPR_MSG.format("writer.setPageMode(val)", "writer.page_mode = val"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1847,8 +1841,7 @@ class PdfWriter:
             Use :py:attr:`page_mode` instead.
         """
         warnings.warn(
-            "pageMode will be removed in PyPDF2 2.0.0. "
-            "Use the page_mode attribute instead.",
+            DEPR_MSG.format("writer.pageMode", "writer.page_mode"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1862,8 +1855,7 @@ class PdfWriter:
             Use :py:attr:`page_mode` instead.
         """
         warnings.warn(
-            "pageMode will be removed in PyPDF2 2.0.0. "
-            "Use the page_mode attribute instead.",
+            DEPR_MSG.format("writer.pageMode", "writer.page_mode"),
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -42,6 +42,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ._utils import (
     DEPR_MSG,
+    DEPR_MSG_NO_REPLACEMENT,
     WHITESPACES,
     StreamType,
     b_,
@@ -78,7 +79,7 @@ class PdfObject:
 
     def getObject(self) -> Optional["PdfObject"]:
         warnings.warn(
-            "getObject will be removed in PyPDF2 2.0.0. Use get_object instead.",
+            DEPR_MSG.format("getObject", "get_object"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -107,8 +108,7 @@ class NullObject(PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -117,8 +117,7 @@ class NullObject(PdfObject):
     @staticmethod
     def readFromStream(stream: StreamType) -> "NullObject":
         warnings.warn(
-            "readFromStream will be removed in PyPDF2 2.0.0. "
-            "Use read_from_stream instead.",
+            DEPR_MSG.format("readFromStream", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -149,8 +148,7 @@ class BooleanObject(PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -170,8 +168,7 @@ class BooleanObject(PdfObject):
     @staticmethod
     def readFromStream(stream: StreamType) -> "BooleanObject":
         warnings.warn(
-            "readFromStream will be removed in PyPDF2 2.0.0. "
-            "Use read_from_stream instead.",
+            DEPR_MSG.format("readFromStream", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -192,8 +189,7 @@ class ArrayObject(list, PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -223,8 +219,7 @@ class ArrayObject(list, PdfObject):
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "ArrayObject":  # PdfReader
         warnings.warn(
-            "readFromStream will be removed in PyPDF2 2.0.0. "
-            "Use read_from_stream instead.",
+            DEPR_MSG.format("readFromStream", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -264,8 +259,7 @@ class IndirectObject(PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -302,8 +296,7 @@ class IndirectObject(PdfObject):
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "IndirectObject":  # PdfReader
         warnings.warn(
-            "readFromStream will be removed in PyPDF2 2.0.0. "
-            "Use read_from_stream instead.",
+            DEPR_MSG.format("readFromStream", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -348,8 +341,7 @@ class FloatObject(decimal.Decimal, PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -379,8 +371,7 @@ class NumberObject(int, PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("readFromStream", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -397,8 +388,7 @@ class NumberObject(int, PdfObject):
     @staticmethod
     def readFromStream(stream: StreamType) -> Union["NumberObject", FloatObject]:
         warnings.warn(
-            "readFromStream will be removed in PyPDF2 2.0.0. "
-            "Use read_from_stream instead.",
+            DEPR_MSG.format("readFromStream", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -532,8 +522,7 @@ class ByteStringObject(bytes_type, PdfObject):  # type: ignore
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -603,8 +592,7 @@ class TextStringObject(str, PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -624,8 +612,7 @@ class NameObject(str, PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -655,8 +642,7 @@ class NameObject(str, PdfObject):
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "NameObject":  # PdfReader
         warnings.warn(
-            "readFromStream will be removed in PyPDF2 2.0.0. "
-            "Use read_from_stream instead.",
+            DEPR_MSG.format("readFromStream", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -714,8 +700,7 @@ class DictionaryObject(dict, PdfObject):
             Use :meth:`xmp_metadata` instead.
         """
         warnings.warn(
-            "getXmpMetadata will be removed in PyPDF2 2.0.0. "
-            "Use xmp_metadata instead.",
+            DEPR_MSG.format("getXmpMetadata()", "xmp_metadata"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -729,7 +714,7 @@ class DictionaryObject(dict, PdfObject):
             Use :meth:`xmp_metadata` instead.
         """
         warnings.warn(
-            "xmpMetadata will be removed in PyPDF2 2.0.0. Use xmp_metadata instead.",
+            DEPR_MSG.format("xmpMetadata", "xmp_metadata"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -750,8 +735,7 @@ class DictionaryObject(dict, PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
         warnings.warn(
-            "writeToStream will be removed in PyPDF2 2.0.0. "
-            "Use write_to_stream instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -888,8 +872,7 @@ class DictionaryObject(dict, PdfObject):
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "DictionaryObject":  # PdfReader
         warnings.warn(
-            "readFromStream will be removed in PyPDF2 2.0.0. "
-            "Use read_from_stream instead.",
+            DEPR_MSG.format("readFromStream()", "read_from_stream"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1405,7 +1388,7 @@ class RectangleObject(ArrayObject):
 
     def ensureIsNumber(self, value: Any) -> Union[FloatObject, NumberObject]:
         warnings.warn(
-            "ensureIsNumber will be removed in PyPDF2 2.0.0. ",
+            DEPR_MSG_NO_REPLACEMENT.format("ensureIsNumber"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1735,8 +1718,7 @@ class Field(TreeObject):
             Use :py:attr:`field_type` instead.
         """
         warnings.warn(
-            "fieldType will be removed in PyPDF2 2.0.0. "
-            "Use the field_type property instead.",
+            DEPR_MSG.format("fieldType", "field_type"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1770,8 +1752,7 @@ class Field(TreeObject):
             Use :py:attr:`alternate_name` instead.
         """
         warnings.warn(
-            "altName will be removed in PyPDF2 2.0.0. "
-            "Use the alternate_name property instead.",
+            DEPR_MSG.format("altName", "alternate_name"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1794,8 +1775,7 @@ class Field(TreeObject):
             Use :py:attr:`mapping_name` instead.
         """
         warnings.warn(
-            "mappingName will be removed in PyPDF2 2.0.0. "
-            "Use the mapping_name property instead.",
+            DEPR_MSG.format("mappingName", "mapping_name"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1830,8 +1810,7 @@ class Field(TreeObject):
             Use :py:attr:`default_value` instead.
         """
         warnings.warn(
-            "defaultValue will be removed in PyPDF2 2.0.0. "
-            "Use the default_value property instead.",
+            DEPR_MSG.format("defaultValue", "default_value"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1854,8 +1833,7 @@ class Field(TreeObject):
             Use :py:attr:`additional_actions` instead.
         """
         warnings.warn(
-            "additionalActions will be removed in PyPDF2 2.0.0. "
-            "Use the additional_actions property instead.",
+            DEPR_MSG.format("additionalActions", "additional_actions"),
             PendingDeprecationWarning,
             stacklevel=2,
         )
@@ -1948,8 +1926,7 @@ class Destination(TreeObject):
             Use :py:attr:`dest_array` instead.
         """
         warnings.warn(
-            "getDestArray will be removed in PyPDF2 2.0.0. "
-            "Use the dest_array property instead.",
+            DEPR_MSG.format("getDestArray", "dest_array"),
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -224,8 +224,7 @@ class XmpInformation(PdfObject):
             Use :meth:`write_to_stream` instead.
         """
         warnings.warn(
-            "writeToStream() will be deprecated in PyPDF2 2.0.0. "
-            "Use write_to_stream() instead.",
+            DEPR_MSG.format("writeToStream", "write_to_stream"),
             PendingDeprecationWarning,
         )
         self.write_to_stream(stream, encryption_key)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -628,8 +628,12 @@ def test_convert_to_int_error():
 
 
 def test_convertToInt_deprecated():
+    msg = (
+        "convertToInt is deprecated and will be removed in PyPDF2 3.0.0. "
+        "Use convert_to_int instead."
+    )
     with pytest.warns(
         PendingDeprecationWarning,
-        match="convertToInt will be removed in PyPDF2 3.0.0. Use convert_to_int instead.",
+        match=msg,
     ):
         assert convertToInt(b"\x01", 8) == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -630,6 +630,6 @@ def test_convert_to_int_error():
 def test_convertToInt_deprecated():
     with pytest.warns(
         PendingDeprecationWarning,
-        match="convertToInt will be removed with PyPDF2 3.0.0. Use convert_to_int instead.",
+        match="convertToInt will be removed in PyPDF2 3.0.0. Use convert_to_int instead.",
     ):
         assert convertToInt(b"\x01", 8) == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -630,6 +630,6 @@ def test_convert_to_int_error():
 def test_convertToInt_deprecated():
     with pytest.warns(
         PendingDeprecationWarning,
-        match="convertToInt will be removed with PyPDF2 2.0.0. Use convert_to_int instead.",
+        match="convertToInt will be removed with PyPDF2 3.0.0. Use convert_to_int instead.",
     ):
         assert convertToInt(b"\x01", 8) == 1


### PR DESCRIPTION
We are trying to break as few running systems as possible. For this
reason we keep the adapter methods / classes in PyPDF2 until 3.0.0.

This commit is done to not confuse people. It will not be backported
to the 1.x branch though.