### PR TITLE
DOC: Fix style of 1.25 and 1.27 patch notes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -520,15 +520,6 @@ Miscellaneous:
 
 You can see the full changelog at: https://github.com/py-pdf/PyPDF2/compare/1.26.0...1.27.0
 
-Version 1.25.1, 2015-07-20
---------------------------
-
- - Fix bug when parsing inline images. Occurred when merging
-   certain pages with inline images
-
- - Fixed type error when creating outlines by utilizing the
-   isString() test
-
 Version 1.26.0, 2016-05-18
 --------------------------
 
@@ -554,6 +545,15 @@ Version 1.26.0, 2016-05-18
 
  - Fix bug where reading an inline image would cut off prematurely
    in certain cases (speedplane)
+
+Version 1.25.1, 2015-07-20
+--------------------------
+
+ - Fix bug when parsing inline images. Occurred when merging
+   certain pages with inline images
+
+ - Fixed type error when creating outlines by utilizing the
+   isString() test
 
 Version 1.25, 2015-07-07
 ------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -444,6 +444,41 @@ Miscellaneous:
 
 All changes: https://github.com/py-pdf/PyPDF2/compare/1.27.3...1.27.4
 
+Version 1.27.3, 2022-04-10
+--------------------------
+
+- PKG: Make Tests not a subpackage (#728)
+- BUG: Fix ASCII85Decode.decode assertion (#729)
+- BUG: Error in Chinese character encoding (#463)
+- BUG: Code duplication in Scripts/2-up.py
+- ROBUST: Guard 'obj.writeToStream' with 'if obj is not None'
+- ROBUST: Ignore a /Prev entry with the value 0 in the trailer
+- MAINT: Remove Sample_Code (#726)
+- TST: Close file handle in test_writer (#722)
+- TST: Fix test_get_images (#730)
+- DEV: Make tox use pytest and add more Python versions (#721)
+- DOC: Many (#720, #723-725, #469)
+
+All changes: https://github.com/py-pdf/PyPDF2/compare/1.27.2...1.27.3
+
+Version 1.27.2, 2022-04-09
+--------------------------
+
+- Add Scripts (including `pdfcat`), Resources, Tests, and Sample_Code back to
+  PyPDF2. It was removed by accident in 1.27.0, but might get removed with 2.0.0
+  See https://github.com/py-pdf/PyPDF2/discussions/718 for discussion
+
+All changes: https://github.com/py-pdf/PyPDF2/compare/1.27.1...1.27.2
+
+Version 1.27.1, 2022-04-08
+--------------------------
+
+- Fixed project links on PyPI page after migration from mstamy2
+  to MartinThoma to the py-pdf organization on GitHub
+- Documentation is now at https://pypdf2.readthedocs.io/en/latest/
+
+All changes: https://github.com/py-pdf/PyPDF2/compare/1.27.0...1.27.1
+
 Version 1.27.0, 2022-04-07
 --------------------------
 
@@ -485,31 +520,14 @@ Miscellaneous:
 
 You can see the full changelog at: https://github.com/py-pdf/PyPDF2/compare/1.26.0...1.27.0
 
-Patch release 1.27.1, 2022-04-08
+Version 1.25.1, 2015-07-20
+--------------------------
 
-- Fixed project links on PyPI page after migration from mstamy2
-  to MartinThoma to the py-pdf organization on GitHub
-- Documentation is now at https://pypdf2.readthedocs.io/en/latest/
+ - Fix bug when parsing inline images. Occurred when merging
+   certain pages with inline images
 
-Patch release 1.27.2, 2022-04-09
-
-- Add Scripts (including `pdfcat`), Resources, Tests, and Sample_Code back to
-  PyPDF2. It was removed by accident in 1.27.0, but might get removed with 2.0.0
-  See https://github.com/py-pdf/PyPDF2/discussions/718 for discussion
-
-Patch release 1.27.3, 2022-04-10
-
-- PKG: Make Tests not a subpackage (#728)
-- BUG: Fix ASCII85Decode.decode assertion (#729)
-- BUG: Error in Chinese character encoding (#463)
-- BUG: Code duplication in Scripts/2-up.py
-- ROBUST: Guard 'obj.writeToStream' with 'if obj is not None'
-- ROBUST: Ignore a /Prev entry with the value 0 in the trailer
-- MAINT: Remove Sample_Code (#726)
-- TST: Close file handle in test_writer (#722)
-- TST: Fix test_get_images (#730)
-- DEV: Make tox use pytest and add more Python versions (#721)
-- DOC: Many (#720, #723-725, #469)
+ - Fixed type error when creating outlines by utilizing the
+   isString() test
 
 Version 1.26.0, 2016-05-18
 --------------------------
@@ -536,15 +554,6 @@ Version 1.26.0, 2016-05-18
 
  - Fix bug where reading an inline image would cut off prematurely
    in certain cases (speedplane)
-
-
-Patch 1.25.1, 2015-07-20
-
- - Fix bug when parsing inline images. Occurred when merging
-   certain pages with inline images
-
- - Fixed type error when creating outlines by utilizing the
-   isString() test
 
 Version 1.25, 2015-07-07
 ------------------------


### PR DESCRIPTION
This PR updates the CHANGELOG entries for `1.25.1`, `1.27.1`, `1.27.2`, and `1.27.3` patches such that they're shown above the minor release, and that they match the style of later `1.27` and `1.28` patch releases.