### PR TITLE
MAINT: Add wrapper function for PendingDeprecationWarnings

### DIFF
--- a/PyPDF2/_merger.py
+++ b/PyPDF2/_merger.py
@@ -25,13 +25,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import warnings
 from io import BytesIO, FileIO, IOBase
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 from ._page import PageObject
 from ._reader import PdfReader
-from ._utils import DEPR_MSG, StrByteType, str_
+from ._utils import deprecate_with_replacement, StrByteType, str_
 from ._writer import PdfWriter
 from .constants import PagesAttributes as PA
 from .generic import (
@@ -321,9 +320,7 @@ class PdfMerger:
 
             Use :meth:`add_metadata` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addMetadata", "add_metadata"), PendingDeprecationWarning
-        )
+        deprecate_with_replacement("addMetadata", "add_metadata")
         self.add_metadata(infos)
 
     def setPageLayout(self, layout: LayoutType) -> None:
@@ -332,11 +329,7 @@ class PdfMerger:
 
             Use :meth:`set_page_layout` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("setPageLayout", "set_page_layout"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("setPageLayout", "set_page_layout")
         self.set_page_layout(layout)
 
     def set_page_layout(self, layout: LayoutType) -> None:
@@ -373,9 +366,7 @@ class PdfMerger:
 
             Use :meth:`set_page_mode` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("setPageMode", "set_page_mode"), PendingDeprecationWarning
-        )
+        deprecate_with_replacement("setPageMode", "set_page_mode")
         self.set_page_mode(mode)
 
     def set_page_mode(self, mode: PagemodeType) -> None:
@@ -639,10 +630,7 @@ class PdfMerger:
         .. deprecated:: 1.28.0
             Use :meth:`add_bookmark` instead.
         """
-        warnings.warn(
-            "addBookmark is deprecated. Use add_bookmark instead.",
-            DeprecationWarning,
-        )
+        deprecate_with_replacement("addBookmark", "add_bookmark")
         return self.add_bookmark(
             title, pagenum, parent, color, bold, italic, fit, *args
         )
@@ -735,10 +723,7 @@ class PdfMerger:
         .. deprecated:: 1.28.0
             Use :meth:`add_named_destination` instead.
         """
-        warnings.warn(
-            "addNamedDestination is deprecated. Use add_named_destination instead.",
-            DeprecationWarning,
-        )
+        deprecate_with_replacement("addNamedDestination", "add_named_destination")
         return self.add_named_destination(title, pagenum)
 
     def add_named_destination(self, title: str, pagenum: int) -> None:
@@ -760,13 +745,8 @@ class PdfMerger:
 
 class PdfFileMerger(PdfMerger):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        import warnings
+        deprecate_with_replacement("PdfFileMerger", "PdfMerge")
 
-        warnings.warn(
-            "PdfFileMerger was renamed to PdfMerger. PdfFileMerger will be removed",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
         if "strict" not in kwargs and len(args) < 1:
             kwargs["strict"] = True  # maintain the default
         super().__init__(*args, **kwargs)

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -29,7 +29,6 @@
 
 import math
 import uuid
-import warnings
 from decimal import Decimal
 from typing import (
     Any,
@@ -44,8 +43,8 @@ from typing import (
 )
 
 from ._utils import (
-    DEPR_MSG,
-    DEPR_MSG_NO_REPLACEMENT,
+    deprecate_no_replacement,
+    deprecate_with_replacement,
     CompressedTransformationMatrix,
     TransformationMatrixType,
     b_,
@@ -85,11 +84,7 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
 
 
 def getRectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleObject:
-    warnings.warn(
-        DEPR_MSG_NO_REPLACEMENT.format("getRectangle"),
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
+    deprecate_no_replacement("getRectangle")
     return _get_rectangle(self, name, defaults)
 
 
@@ -100,11 +95,7 @@ def _set_rectangle(self: Any, name: str, value: Union[RectangleObject, float]) -
 
 
 def setRectangle(self: Any, name: str, value: Union[RectangleObject, float]) -> None:
-    warnings.warn(
-        DEPR_MSG_NO_REPLACEMENT.format("setRectangle"),
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
+    deprecate_no_replacement("setRectangle")
     _set_rectangle(self, name, value)
 
 
@@ -113,11 +104,7 @@ def _delete_rectangle(self: Any, name: str) -> None:
 
 
 def deleteRectangle(self: Any, name: str) -> None:
-    warnings.warn(
-        DEPR_MSG_NO_REPLACEMENT.format("deleteRectangle"),
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
+    deprecate_no_replacement("deleteRectangle")
     del self[name]
 
 
@@ -130,11 +117,7 @@ def _create_rectangle_accessor(name: str, fallback: Iterable[str]) -> property:
 
 
 def createRectangleAccessor(name: str, fallback: Iterable[str]) -> property:
-    warnings.warn(
-        DEPR_MSG_NO_REPLACEMENT.format("createRectangleAccessor"),
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
+    deprecate_no_replacement("createRectangleAccessor")
     return _create_rectangle_accessor(name, fallback)
 
 
@@ -302,11 +285,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`create_blank_page` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("createBlankPage", "create_blank_page"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("createBlankPage", "create_blank_page")
         return PageObject.create_blank_page(pdf, width, height)
 
     def rotate(self, angle: float) -> "PageObject":
@@ -326,11 +305,7 @@ class PageObject(DictionaryObject):
         return self
 
     def rotate_clockwise(self, angle: float) -> "PageObject":
-        warnings.warn(
-            DEPR_MSG.format("rotate_clockwise", "rotate"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("rotate_clockwise", "rotate")
         return self.rotate(angle)
 
     def rotateClockwise(self, angle: float) -> "PageObject":
@@ -339,11 +314,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`rotate_clockwise` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("rotateClockwise", "rotate"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("rotateClockwise", "rotate")
         return self.rotate(angle)
 
     def rotateCounterClockwise(self, angle: float) -> "PageObject":
@@ -352,11 +323,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`rotate_clockwise` with a negative argument instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("rotateCounterClockwise", "rotate"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("rotateCounterClockwise", "rotate")
         return self.rotate(-angle)
 
     @staticmethod
@@ -452,9 +419,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`get_contents` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getContents", "get_contents"),
-        )
+        deprecate_with_replacement("getContents", "get_contents")
         return self.get_contents()
 
     def merge_page(self, page2: "PageObject", expand: bool = False) -> None:
@@ -480,9 +445,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`merge_page` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("mergePage", "merge_page"),
-        )
+        deprecate_with_replacement("mergePage", "merge_page")
         return self.merge_page(page2)
 
     def _merge_page(
@@ -637,14 +600,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation`  and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "page.mergeTransformedPage(page2, ctm)",
-                "page2.add_transformation(ctm); page.merge_page(page2)",
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeTransformedPage(page2, ctm)", "page2.add_transformation(ctm); page.merge_page(page2)")
         if isinstance(ctm, Transformation):
             ctm = ctm.ctm
         ctm = cast(CompressedTransformationMatrix, ctm)
@@ -674,14 +630,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            "page.mergeScaledPage(page2, scale, expand) method will be deprecated. "
-            "Use "
-            "page2.add_transformation(Transformation().scale(scale)); "
-            "page.merge_page(page2, expand) instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeScaledPage(page2, scale, expand)", "page2.add_transformation(Transformation().scale(scale)); page.merge_page(page2, expand)")
         op = Transformation().scale(scale, scale)
         self.mergeTransformedPage(page2, op, expand)
 
@@ -702,14 +651,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            "page.mergeRotatedPage(page2, rotation, expand) method will be deprecated. "
-            "Use "
-            "page2.add_transformation(Transformation().rotate(rotation)); "
-            "page.merge_page(page2, expand) instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeRotatedPage(page2, rotation, expand)", "page2.add_transformation(Transformation().rotate(rotation)); page.merge_page(page2, expand)")
         op = Transformation().rotate(rotation)
         self.mergeTransformedPage(page2, op, expand)
 
@@ -731,14 +673,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            "page.mergeTranslatedPage(page2, tx, ty, expand) method will be deprecated. "
-            "Use "
-            "page2.add_transformation(Transformation().translate(tx, ty)); "
-            "page.merge_page(page2, expand) instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeTranslatedPage(page2, tx, ty, expand)", "page2.add_transformation(Transformation().translate(tx, ty)); page.merge_page(page2, expand)")
         op = Transformation().translate(tx, ty)
         self.mergeTransformedPage(page2, op, expand)
 
@@ -766,14 +701,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            "page.mergeRotatedTranslatedPage(page2, rotation, tx, ty, expand) "
-            "method will be deprecated. Use "
-            "page2.add_transformation(Transformation().rotate(rotation).translate(tx, ty)); "
-            "page.merge_page(page2, expand) instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeRotatedTranslatedPage(page2, rotation, tx, ty, expand)", "page2.add_transformation(Transformation().rotate(rotation).translate(tx, ty)); page.merge_page(page2, expand)")
         op = Transformation().translate(-tx, -ty).rotate(rotation).translate(tx, ty)
         return self.mergeTransformedPage(page2, op, expand)
 
@@ -795,14 +723,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            "page.mergeRotatedScaledPage(page2, rotation, scale, expand) "
-            "method will be deprecated. Use "
-            "page2.add_transformation(Transformation().rotate(rotation).scale(scale)); "
-            "page.merge_page(page2, expand) instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeRotatedScaledPage(page2, rotation, scale, expand)", "page2.add_transformation(Transformation().rotate(rotation).scale(scale)); page.merge_page(page2, expand)")
         op = Transformation().rotate(rotation).scale(scale, scale)
         self.mergeTransformedPage(page2, op, expand)
 
@@ -830,14 +751,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            "page.mergeScaledTranslatedPage(page2, scale, tx, ty, expand) "
-            "method will be deprecated. Use "
-            "page2.add_transformation(Transformation().scale(scale).translate(tx, ty)); "
-            "page.merge_page(page2, expand) instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeScaledTranslatedPage(page2, scale, tx, ty, expand)", "page2.add_transformation(Transformation().scale(scale).translate(tx, ty)); page.merge_page(page2, expand)")
         op = Transformation().scale(scale, scale).translate(tx, ty)
         return self.mergeTransformedPage(page2, op, expand)
 
@@ -868,14 +782,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` and :meth:`merge_page` instead.
         """
-        warnings.warn(
-            "page.mergeRotatedScaledTranslatedPage(page2, rotation, tx, ty, expand) "
-            "method will be deprecated. Use "
-            "page2.add_transformation(Transformation().rotate(rotation).scale(scale)); "
-            "page.merge_page(page2, expand) instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("page.mergeRotatedScaledTranslatedPage(page2, rotation, tx, ty, expand)", "page2.add_transformation(Transformation().rotate(rotation).scale(scale)); page.merge_page(page2, expand)")
         op = Transformation().rotate(rotation).scale(scale, scale).translate(tx, ty)
         self.mergeTransformedPage(page2, op, expand)
 
@@ -941,11 +848,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`add_transformation` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addTransformation", "add_transformation"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("addTransformation", "add_transformation")
         self.add_transformation(ctm)
 
     def scale(self, sx: float, sy: float) -> None:
@@ -1001,11 +904,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`scale_by` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.scaleBy", "Page.scale_by"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("scaleBy", "scale_by")
         self.scale(factor, factor)
 
     def scale_to(self, width: float, height: float) -> None:
@@ -1026,11 +925,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`scale_to` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.scaleTo", "Page.scale_to"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("scaleTo", "scale_to")
         self.scale_to(width, height)
 
     def compress_content_streams(self) -> None:
@@ -1053,13 +948,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`compress_content_streams` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "Page.compressContentStreams", "Page.compress_content_streams"
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("compressContentStreams", "compress_content_streams")
         self.compress_content_streams()
 
     def extract_text(self, Tj_sep: str = "", TJ_sep: str = "") -> str:
@@ -1152,11 +1041,7 @@ class PageObject(DictionaryObject):
 
             Use :meth:`extract_text` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.extractText", "Page.extract_text"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("extractText", "extract_text")
         return self.extract_text(Tj_sep=Tj_sep, TJ_sep=TJ_sep)
 
     mediabox = _create_rectangle_accessor(PG.MEDIABOX, ())
@@ -1173,11 +1058,7 @@ class PageObject(DictionaryObject):
 
             Use :py:attr:`mediabox` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.mediaBox", "Page.mediabox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("mediaBox", "mediabox")
         return self.mediabox
 
     @mediaBox.setter
@@ -1187,11 +1068,7 @@ class PageObject(DictionaryObject):
 
             Use :py:attr:`mediabox` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.mediaBox", "Page.mediabox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("mediaBox", "mediabox")
         self.mediabox = value
 
     cropbox = _create_rectangle_accessor("/CropBox", (PG.MEDIABOX,))
@@ -1210,20 +1087,12 @@ class PageObject(DictionaryObject):
 
             Use :py:attr:`cropbox` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.cropBox", "Page.cropbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("cropBox", "cropbox")
         return self.cropbox
 
     @cropBox.setter
     def cropBox(self, value: RectangleObject) -> None:
-        warnings.warn(
-            DEPR_MSG.format("Page.cropBox", "Page.cropbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("cropBox", "cropbox")
         self.cropbox = value
 
     bleedbox = _create_rectangle_accessor("/BleedBox", ("/CropBox", PG.MEDIABOX))
@@ -1240,20 +1109,12 @@ class PageObject(DictionaryObject):
 
             Use :py:attr:`bleedbox` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.bleedBox", "Page.bleedbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("bleedBox", "bleedbox")
         return self.bleedbox
 
     @bleedBox.setter
     def bleedBox(self, value: RectangleObject) -> None:
-        warnings.warn(
-            DEPR_MSG.format("Page.bleedBox", "Page.bleedbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("bleedBox", "bleedbox")
         self.bleedbox = value
 
     trimbox = _create_rectangle_accessor("/TrimBox", ("/CropBox", PG.MEDIABOX))
@@ -1269,20 +1130,12 @@ class PageObject(DictionaryObject):
 
             Use :py:attr:`trimbox` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.trimBox", "Page.trimbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("trimBox", "trimbox")
         return self.trimbox
 
     @trimBox.setter
     def trimBox(self, value: RectangleObject) -> None:
-        warnings.warn(
-            DEPR_MSG.format("Page.trimBox", "Page.trimbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("trimBox", "trimbox")
         self.trimbox = value
 
     artbox = _create_rectangle_accessor("/ArtBox", ("/CropBox", PG.MEDIABOX))
@@ -1299,20 +1152,12 @@ class PageObject(DictionaryObject):
 
             Use :py:attr:`artbox` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("Page.artBox", "Page.artbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("artBox", "artbox")
         return self.artbox
 
     @artBox.setter
     def artBox(self, value: RectangleObject) -> None:
-        warnings.warn(
-            DEPR_MSG.format("Page.artBox", "Page.artbox"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("artBox", "artbox")
         self.artbox = value
 
 

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -47,8 +47,8 @@ from typing import (
 from ._page import PageObject, _VirtualList
 from ._security import RC4_encrypt, _alg33_1, _alg34, _alg35
 from ._utils import (
-    DEPR_MSG,
-    DEPR_MSG_NO_REPLACEMENT,
+    deprecate_no_replacement,
+    deprecate_with_replacement,
     StrByteType,
     StreamType,
     b_,
@@ -103,11 +103,7 @@ def convert_to_int(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
 
 
 def convertToInt(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
-    warnings.warn(
-        DEPR_MSG.format("convertToInt", "convert_to_int"),
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
+    deprecate_with_replacement("convertToInt", "convert_to_int")
     return convert_to_int(d, size)
 
 
@@ -142,11 +138,7 @@ class DocumentInformation(DictionaryObject):
 
             Use the attributes (e.g. :py:attr:`title` / :py:attr:`author`).
         """
-        warnings.warn(
-            DEPR_MSG_NO_REPLACEMENT.format("getText"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_no_replacement("getText")
         return self._get_text(key)
 
     @property
@@ -290,13 +282,7 @@ class PdfReader:
 
             Use the attribute :py:attr:`metadata` instead.
         """
-        warnings.warn(
-            "The `getDocumentInfo` method of PdfReader will be replaced by the "
-            "`metadata` attribute in PyPDF2 3.0.0. You can switch to the "
-            "metadata attribute already.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getDocumentInfo", "metadata")
         return self.metadata
 
     @property
@@ -306,13 +292,7 @@ class PdfReader:
 
             Use the attribute :py:attr:`metadata` instead.
         """
-        warnings.warn(
-            "The `documentInfo` attribute of PdfReader will be replaced by "
-            "`metadata` in PyPDF2 3.0.0. You can switch to the metadata "
-            "attribute already.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("documentInfo", "metadata")
         return self.metadata
 
     @property
@@ -337,13 +317,7 @@ class PdfReader:
 
             Use the attribute :py:attr:`xmp_metadata` instead.
         """
-        warnings.warn(
-            "The `getXmpMetadata` method of PdfReader will be replaced by the "
-            "`xmp_metadata` attribute in PyPDF2 3.0.0. You can switch to the "
-            "xmp_metadata attribute already.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getXmpMetadata", "xmp_metadata")
         return self.xmp_metadata
 
     @property
@@ -353,13 +327,7 @@ class PdfReader:
 
             Use the attribute :py:attr:`xmp_metadata` instead.
         """
-        warnings.warn(
-            "The `xmpMetadata` attribute of PdfReader will be replaced by the "
-            "`xmp_metadata` attribute in PyPDF2 3.0.0. You can switch to the "
-            "xmp_metadata attribute already.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("xmpMetadata", "xmp_metadata")
         return self.xmp_metadata
 
     def _get_num_pages(self) -> int:
@@ -395,11 +363,7 @@ class PdfReader:
 
             Use :code:`len(reader.pages)` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getNumPages", "len(reader.pages)"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("reader.getNumPages", "len(reader.pages)")
         return self._get_num_pages()
 
     @property
@@ -409,12 +373,7 @@ class PdfReader:
 
             Use :code:`len(reader.pages)` instead.
         """
-        warnings.warn(
-            "The `numPages` attribute of PdfReader will be removed in PyPDF2 3.0.0. "
-            "Use `len(reader.pages)` instead.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("reader.numPages", "len(reader.pages)")
         return self._get_num_pages()
 
     def getPage(self, pageNumber: int) -> PageObject:
@@ -423,11 +382,7 @@ class PdfReader:
 
             Use :code:`reader.pages[pageNumber]` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getPage(pageNumber)", "reader.pages[pageNumber]"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("reader.getPage(pageNumber)", "reader.pages[pageNumber]")
         return self._get_page(pageNumber)
 
     def _get_page(self, page_number: int) -> PageObject:
@@ -453,11 +408,7 @@ class PdfReader:
 
             Use :py:attr:`named_destinations` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.namedDestinations", "reader.named_destinations"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("namedDestinations", "named_destinations")
         return self.named_destinations
 
     @property
@@ -535,11 +486,7 @@ class PdfReader:
 
             Use :meth:`get_fields` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getFields", "reader.get_fields"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getFields", "get_fields")
         return self.get_fields(tree, retval, fileobj)
 
     def _build_field(
@@ -617,11 +564,7 @@ class PdfReader:
 
             Use :meth:`get_form_text_fields` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getFormTextFields", "reader.get_form_text_fields"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getFormTextFields", "get_form_text_fields")
         return self.get_form_text_fields()
 
     def _get_named_destinations(
@@ -680,11 +623,7 @@ class PdfReader:
 
             Use :py:attr:`named_destinations` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getNamedDestinations", "reader.named_destinations"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getNamedDestinations", "named_destinations")
         return self._get_named_destinations(tree, retval)
 
     @property
@@ -748,11 +687,7 @@ class PdfReader:
 
             Use :py:attr:`outlines` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getOutlines", "reader.outlines"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getOutlines", "outlines")
         return self._get_outlines(node, outlines)
 
     def _get_page_number_by_indirect(
@@ -792,13 +727,7 @@ class PdfReader:
 
             Use :meth:`get_page_number` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "reader.getPageNumber(page)", "reader.get_page_number(page)"
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getPageNumber", "get_page_number")
         return self.get_page_number(page)
 
     def get_destination_page_number(self, destination: Destination) -> int:
@@ -817,13 +746,7 @@ class PdfReader:
 
             Use :meth:`get_destination_page_number` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "reader.getDestinationPageNumber", "reader.get_destination_page_number"
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getDestinationPageNumber", "get_destination_page_number")
         return self.get_destination_page_number(destination)
 
     def _build_destination(
@@ -915,11 +838,7 @@ class PdfReader:
 
             Use :py:attr:`page_layout` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getPageLayout()", "reader.page_layout"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getPageLayout", "page_layout")
         return self.page_layout
 
     @property
@@ -929,11 +848,7 @@ class PdfReader:
 
             Use :py:attr:`page_layout` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.pageLayout", "reader.page_layout"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("pageLayout", "page_layout")
         return self.page_layout
 
     @property
@@ -971,11 +886,7 @@ class PdfReader:
 
             Use :py:attr:`page_mode` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getPageMode()", "reader.page_mode"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getPageMode", "page_mode")
         return self.page_mode
 
     @property
@@ -985,11 +896,7 @@ class PdfReader:
 
             Use :py:attr:`page_mode` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.pageMode", "reader.page_mode"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("pageMode", "page_mode")
         return self.page_mode
 
     def _flatten(
@@ -1165,14 +1072,7 @@ class PdfReader:
 
             Use :meth:`get_object` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "reader.getObject(indirectReference)",
-                "reader.get_object(indirect_reference)",
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getObject", "get_object")
         return self.get_object(indirectReference)
 
     def _decrypt_object(
@@ -1239,11 +1139,7 @@ class PdfReader:
 
             Use :meth:`read_object_header` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.readObjectHeader", "reader.read_object_header"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readObjectHeader", "read_object_header")
         return self.read_object_header(stream)
 
     def cache_get_indirect_object(
@@ -1259,13 +1155,7 @@ class PdfReader:
 
             Use :meth:`cache_get_indirect_object` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "reader.cacheGetIndirectObject", "reader.cache_get_indirect_object"
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("cacheGetIndirectObject", "cache_get_indirect_object")
         return self.cache_get_indirect_object(generation, idnum)
 
     def cache_indirect_object(
@@ -1288,13 +1178,7 @@ class PdfReader:
 
             Use :meth:`cache_indirect_object` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "reader.cacheIndirectObject", "reader.cache_indirect_object"
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("cacheIndirectObject", "cache_indirect_object")
         return self.cache_indirect_object(generation, idnum, obj)
 
     def read(self, stream: StreamType) -> None:
@@ -1684,11 +1568,7 @@ class PdfReader:
 
             Use :meth:`read_next_end_line` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.readNextEndLine", "reader.read_next_end_line"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readNextEndLine", "read_next_end_line")
         return self.read_next_end_line(stream, limit_offset)
 
     def decrypt(self, password: Union[str, bytes]) -> int:
@@ -1837,11 +1717,7 @@ class PdfReader:
 
             Use :py:attr:`is_encrypted` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.getIsEncrypted()", "reader.is_encrypted"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getIsEncrypted", "is_encrypted")
         return self.is_encrypted
 
     @property
@@ -1851,23 +1727,13 @@ class PdfReader:
 
             Use :py:attr:`is_encrypted` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("reader.isEncrypted", "reader.is_encrypted"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("isEncrypted", "is_encrypted")
         return self.is_encrypted
 
 
 class PdfFileReader(PdfReader):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        import warnings
-
-        warnings.warn(
-            "PdfFileReader was renamed to PdfReader. PdfFileReader will be removed",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("PdfFileReader", "PdfReader")
         if "strict" not in kwargs and len(args) < 2:
             kwargs["strict"] = True  # maintain the default
         super().__init__(*args, **kwargs)

--- a/PyPDF2/_utils.py
+++ b/PyPDF2/_utils.py
@@ -241,17 +241,13 @@ def paeth_predictor(left: int, up: int, up_left: int) -> int:
         return up_left
 
 
+def deprecate(msg: str, stacklevel: int = 3) -> None:
+    warnings.warn(msg, PendingDeprecationWarning, stacklevel=stacklevel)
+
+
 def deprecate_with_replacement(old_name: str, new_name: str) -> None:
-    warnings.warn(
-        DEPR_MSG.format(old_name, new_name),
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
+    deprecate(DEPR_MSG.format(old_name, new_name), 4)
 
 
 def deprecate_no_replacement(name: str) -> None:
-    warnings.warn(
-        DEPR_MSG_NO_REPLACEMENT.format(name),
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
+    deprecate(DEPR_MSG_NO_REPLACEMENT.format(name), 4)

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -41,7 +41,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from ._page import PageObject, _VirtualList
 from ._reader import PdfReader
 from ._security import _alg33, _alg34, _alg35
-from ._utils import DEPR_MSG, StreamType, b_
+from ._utils import deprecate_with_replacement, StreamType, b_
 from .constants import CatalogAttributes as CA
 from .constants import Core as CO
 from .constants import EncryptionDictAttributes as ED
@@ -141,11 +141,7 @@ class PdfWriter:
 
             Use :meth:`get_object` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getObject()", "get_object()"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getObject", "get_object")
         return self.get_object(ido)
 
     def _add_page(
@@ -196,11 +192,7 @@ class PdfWriter:
 
             Use :meth:`add_page` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addPage()", "add_page()"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("addPage", "add_page")
         self.add_page(page)
 
     def insert_page(self, page: PageObject, index: int = 0) -> None:
@@ -220,11 +212,7 @@ class PdfWriter:
 
             Use :meth:`insert_page` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("insertPage()", "insert_page()"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("insertPage", "insert_page")
         self.insert_page(page, index)
 
     def get_page(self, pageNumber: int) -> PageObject:
@@ -246,11 +234,7 @@ class PdfWriter:
 
             Use :code:`writer.pages[page_number]` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getPage()", "writer.pages[page_number]"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getPage", "writer.pages[page_number]")
         return self.get_page(pageNumber)
 
     def _get_num_pages(self) -> int:
@@ -267,11 +251,7 @@ class PdfWriter:
 
             Use :code:`len(writer.pages)` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getNumPages()", "len(writer.pages)"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getNumPages", "len(writer.pages)")
         return self._get_num_pages()
 
     @property
@@ -309,11 +289,7 @@ class PdfWriter:
 
             Use :meth:`add_blank_page` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addBlankPage", "add_blank_page"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("addBlankPage", "add_blank_page")
         return self.add_blank_page(width, height)
 
     def insert_blank_page(
@@ -355,11 +331,7 @@ class PdfWriter:
 
             Use :meth:`insertBlankPage` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("insertBlankPage", "insert_blank_page"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("insertBlankPage", "insert_blank_page")
         return self.insert_blank_page(width, height, index)
 
     def add_js(self, javascript: str) -> None:
@@ -411,11 +383,7 @@ class PdfWriter:
 
             Use :meth:`add_js` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addJS", "add_js"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("addJS", "add_js")
         return self.add_js(javascript)
 
     def add_attachment(self, filename: str, data: Union[str, bytes]) -> None:
@@ -507,11 +475,7 @@ class PdfWriter:
 
             Use :meth:`add_attachment` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "addAttachment(fname, fdata)", "add_attachment(filename, data)"
-            ),
-        )
+        deprecate_with_replacement("addAttachment", "add_attachment")
         return self.add_attachment(fname, fdata)
 
     def append_pages_from_reader(
@@ -554,11 +518,7 @@ class PdfWriter:
 
             Use :meth:`append_pages_from_reader` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("appendPagesFromReader", "append_pages_from_reader"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("appendPagesFromReader", "append_pages_from_reader")
         self.append_pages_from_reader(reader, after_page_append)
 
     def update_page_form_field_values(
@@ -604,13 +564,7 @@ class PdfWriter:
 
             Use :meth:`update_page_form_field_values` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "updatePageFormFieldValues", "update_page_form_field_values"
-            ),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("updatePageFormFieldValues", "update_page_form_field_values")
         return self.update_page_form_field_values(page, fields, flags)
 
     def clone_reader_document_root(self, reader: PdfReader) -> None:
@@ -628,11 +582,7 @@ class PdfWriter:
 
             Use :meth:`clone_reader_document_root` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("cloneReaderDocumentRoot", "clone_reader_document_root"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("cloneReaderDocumentRoot", "clone_reader_document_root")
         self.clone_reader_document_root(reader)
 
     def clone_document_from_reader(
@@ -665,11 +615,7 @@ class PdfWriter:
 
             Use :meth:`clone_document_from_reader` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("cloneDocumentFromReader", "clone_document_from_reader"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("cloneDocumentFromReader", "clone_document_from_reader")
         self.clone_document_from_reader(reader, after_page_append)
 
     def encrypt(
@@ -845,9 +791,7 @@ class PdfWriter:
 
             Use :meth:`add_metadata` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addMetadata", "add_metadata"),
-        )
+        deprecate_with_replacement("addMetadata", "add_metadata")
         self.add_metadata(infos)
 
     def _sweep_indirect_references(
@@ -942,11 +886,7 @@ class PdfWriter:
 
             Use :meth:`get_reference` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getReference", "get_reference"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getReference", "get_reference")
         return self.get_reference(obj)
 
     def get_outline_root(self) -> TreeObject:
@@ -970,11 +910,7 @@ class PdfWriter:
 
             Use :meth:`get_outline_root` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getOutlineRoot", "get_outline_root"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getOutlineRoot", "get_outline_root")
         return self.get_outline_root()
 
     def get_named_dest_root(self) -> ArrayObject:
@@ -1022,11 +958,7 @@ class PdfWriter:
 
             Use :meth:`get_named_dest_root` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getNamedDestRoot", "get_named_dest_root"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getNamedDestRoot", "get_named_dest_root")
         return self.get_named_dest_root()
 
     def add_bookmark_destination(
@@ -1052,9 +984,7 @@ class PdfWriter:
 
             Use :meth:`add_bookmark_destination` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addBookmarkDestination", "add_bookmark_destination"),
-        )
+        deprecate_with_replacement("addBookmarkDestination", "add_bookmark_destination")
         return self.add_bookmark_destination(dest, parent)
 
     def add_bookmark_dict(
@@ -1094,9 +1024,7 @@ class PdfWriter:
 
             Use :meth:`add_bookmark_dict` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addBookmarkDict", "add_bookmark_dict"),
-        )
+        deprecate_with_replacement("addBookmarkDict", "add_bookmark_dict")
         return self.add_bookmark_dict(bookmark, parent)
 
     def add_bookmark(
@@ -1193,11 +1121,7 @@ class PdfWriter:
 
             Use :meth:`add_bookmark` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addBookmark", "add_bookmark"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("addBookmark", "add_bookmark")
         return self.add_bookmark(
             title, pagenum, parent, color, bold, italic, fit, *args
         )
@@ -1215,11 +1139,7 @@ class PdfWriter:
 
             Use :meth:`add_named_destination_object` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "addNamedDestinationObject", "add_named_destination_object"
-            ),
-        )
+        deprecate_with_replacement("addNamedDestinationObject", "add_named_destination_object")
         return self.add_named_destination_object(dest)
 
     def add_named_destination(self, title: str, pagenum: int) -> IndirectObject:
@@ -1245,9 +1165,7 @@ class PdfWriter:
 
             Use :meth:`add_named_destination` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addNamedDestination", "add_named_destination"),
-        )
+        deprecate_with_replacement("addNamedDestination", "add_named_destination")
         return self.add_named_destination(title, pagenum)
 
     def remove_links(self) -> None:
@@ -1265,9 +1183,7 @@ class PdfWriter:
 
             Use :meth:`remove_links` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("removeLinks", "remove_links"),
-        )
+        deprecate_with_replacement("removeLinks", "remove_links")
         return self.remove_links()
 
     def remove_images(self, ignore_byte_string_object: bool = False) -> None:
@@ -1353,12 +1269,7 @@ class PdfWriter:
 
             Use :meth:`remove_images` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "removeImages(ignoreByteStringObject=False)",
-                "remove_images(ignore_byte_string_object=False)",
-            ),
-        )
+        deprecate_with_replacement("removeImages", "remove_images")
         return self.remove_images(ignoreByteStringObject)
 
     def remove_text(self, ignore_byte_string_object: bool = False) -> None:
@@ -1412,12 +1323,7 @@ class PdfWriter:
 
             Use :meth:`remove_text` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format(
-                "removeText(ignoreByteStringObject=False)",
-                "remove_text(ignore_byte_string_object=False)",
-            ),
-        )
+        deprecate_with_replacement("removeText", "remove_text")
         return self.remove_text(ignoreByteStringObject)
 
     def add_uri(
@@ -1501,9 +1407,7 @@ class PdfWriter:
 
             Use :meth:`add_uri` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addURI", "add_uri"),
-        )
+        deprecate_with_replacement("addURI", "add_uri")
         return self.add_uri(pagenum, uri, rect, border)
 
     def add_link(
@@ -1613,9 +1517,7 @@ class PdfWriter:
 
             Use :meth:`add_link` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("addLink", "add_link"),
-        )
+        deprecate_with_replacement("addLink", "add_link")
         return self.add_link(pagenum, pagedest, rect, border, fit, *args)
 
     _valid_layouts = [
@@ -1640,11 +1542,7 @@ class PdfWriter:
 
             Use :py:attr:`page_layout` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.getPageLayout", "writer.page_layout"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getPageLayout", "page_layout")
         return self._get_page_layout()
 
     def _set_page_layout(self, layout: Union[NameObject, LayoutType]) -> None:
@@ -1685,11 +1583,7 @@ class PdfWriter:
 
             Use :py:attr:`page_layout` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.setPageLayout(val)", "writer.page_layout = val"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writer.setPageLayout(val)", "writer.page_layout = val")
         return self._set_page_layout(layout)
 
     @property
@@ -1728,11 +1622,7 @@ class PdfWriter:
 
             Use :py:attr:`page_layout` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.pageLayout", "writer.page_layout"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("pageLayout", "page_layout")
         return self.page_layout
 
     @pageLayout.setter
@@ -1742,11 +1632,7 @@ class PdfWriter:
 
             Use :py:attr:`page_layout` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.pageLayout", "writer.page_layout"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("pageLayout", "page_layout")
         self.page_layout = layout
 
     _valid_modes = [
@@ -1770,11 +1656,7 @@ class PdfWriter:
 
             Use :py:attr:`page_mode` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.getPageMode()", "writer.page_mode"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getPageMode", "page_mode")
         return self._get_page_mode()
 
     def set_page_mode(self, mode: PagemodeType) -> None:
@@ -1799,11 +1681,7 @@ class PdfWriter:
 
             Use :py:attr:`page_mode` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.setPageMode(val)", "writer.page_mode = val"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writer.setPageMode(val)", "writer.page_mode = val")
         self.set_page_mode(mode)
 
     @property
@@ -1840,11 +1718,7 @@ class PdfWriter:
 
             Use :py:attr:`page_mode` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.pageMode", "writer.page_mode"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("pageMode", "page_mode")
         return self.page_mode
 
     @pageMode.setter
@@ -1854,21 +1728,11 @@ class PdfWriter:
 
             Use :py:attr:`page_mode` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writer.pageMode", "writer.page_mode"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("pageMode", "page_mode")
         self.page_mode = mode
 
 
 class PdfFileWriter(PdfWriter):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        import warnings
-
-        warnings.warn(
-            "PdfFileWriter was renamed to PdfWriter. PdfFileWriter will be removed",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("PdfFileWriter", "PdfWriter")
         super().__init__(*args, **kwargs)

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -41,8 +41,8 @@ from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ._utils import (
-    DEPR_MSG,
-    DEPR_MSG_NO_REPLACEMENT,
+    deprecate_no_replacement,
+    deprecate_with_replacement,
     WHITESPACES,
     StreamType,
     b_,
@@ -78,11 +78,7 @@ class PdfObject:
         return self
 
     def getObject(self) -> Optional["PdfObject"]:
-        warnings.warn(
-            DEPR_MSG.format("getObject", "get_object"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getObject", "get_object")
         return self.get_object()
 
     def write_to_stream(
@@ -107,20 +103,12 @@ class NullObject(PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     @staticmethod
     def readFromStream(stream: StreamType) -> "NullObject":
-        warnings.warn(
-            DEPR_MSG.format("readFromStream", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readFromStream", "read_from_stream")
         return NullObject.read_from_stream(stream)
 
 
@@ -147,11 +135,7 @@ class BooleanObject(PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     @staticmethod
@@ -167,11 +151,7 @@ class BooleanObject(PdfObject):
 
     @staticmethod
     def readFromStream(stream: StreamType) -> "BooleanObject":
-        warnings.warn(
-            DEPR_MSG.format("readFromStream", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readFromStream", "read_from_stream")
         return BooleanObject.read_from_stream(stream)
 
 
@@ -188,11 +168,7 @@ class ArrayObject(list, PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     @staticmethod
@@ -218,11 +194,7 @@ class ArrayObject(list, PdfObject):
 
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "ArrayObject":  # PdfReader
-        warnings.warn(
-            DEPR_MSG.format("readFromStream", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readFromStream", "read_from_stream")
         return ArrayObject.read_from_stream(stream, pdf)
 
 
@@ -258,11 +230,7 @@ class IndirectObject(PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     @staticmethod
@@ -295,11 +263,7 @@ class IndirectObject(PdfObject):
 
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "IndirectObject":  # PdfReader
-        warnings.warn(
-            DEPR_MSG.format("readFromStream", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readFromStream", "read_from_stream")
         return IndirectObject.read_from_stream(stream, pdf)
 
 
@@ -340,11 +304,7 @@ class FloatObject(decimal.Decimal, PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
 
@@ -370,11 +330,7 @@ class NumberObject(int, PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("readFromStream", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     @staticmethod
@@ -387,11 +343,7 @@ class NumberObject(int, PdfObject):
 
     @staticmethod
     def readFromStream(stream: StreamType) -> Union["NumberObject", FloatObject]:
-        warnings.warn(
-            DEPR_MSG.format("readFromStream", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readFromStream", "read_from_stream")
         return NumberObject.read_from_stream(stream)
 
 
@@ -521,11 +473,7 @@ class ByteStringObject(bytes_type, PdfObject):  # type: ignore
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
 
@@ -591,11 +539,7 @@ class TextStringObject(str, PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
 
@@ -611,11 +555,7 @@ class NameObject(str, PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     @staticmethod
@@ -641,11 +581,7 @@ class NameObject(str, PdfObject):
 
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "NameObject":  # PdfReader
-        warnings.warn(
-            DEPR_MSG.format("readFromStream", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readFromStream", "read_from_stream")
         return NameObject.read_from_stream(stream, pdf)
 
 
@@ -699,11 +635,7 @@ class DictionaryObject(dict, PdfObject):
 
             Use :meth:`xmp_metadata` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getXmpMetadata()", "xmp_metadata"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getXmpMetadata", "xmp_metadata")
         return self.xmp_metadata
 
     @property
@@ -713,11 +645,7 @@ class DictionaryObject(dict, PdfObject):
 
             Use :meth:`xmp_metadata` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("xmpMetadata", "xmp_metadata"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("xmpMetadata", "xmp_metadata")
         return self.xmp_metadata
 
     def write_to_stream(
@@ -734,11 +662,7 @@ class DictionaryObject(dict, PdfObject):
     def writeToStream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     @staticmethod
@@ -871,11 +795,7 @@ class DictionaryObject(dict, PdfObject):
 
     @staticmethod
     def readFromStream(stream: StreamType, pdf: Any) -> "DictionaryObject":  # PdfReader
-        warnings.warn(
-            DEPR_MSG.format("readFromStream()", "read_from_stream"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("readFromStream", "read_from_stream")
         return DictionaryObject.read_from_stream(stream, pdf)
 
 
@@ -901,11 +821,7 @@ class TreeObject(DictionaryObject):
             child = child["/Next"]  # type: ignore
 
     def addChild(self, child: Any, pdf: Any) -> None:  # PdfReader
-        warnings.warn(
-            DEPR_MSG.format("addChild", "add_child"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("addChild", "add_child")
         self.add_child(child, pdf)
 
     def add_child(self, child: Any, pdf: Any) -> None:  # PdfReader
@@ -934,11 +850,7 @@ class TreeObject(DictionaryObject):
         child_obj[NameObject("/Parent")] = parent_ref
 
     def removeChild(self, child: Any) -> None:
-        warnings.warn(
-            DEPR_MSG.format("removeChild", "remove_child"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("removeChild", "remove_child")
         self.remove_child(child)
 
     def remove_child(self, child: Any) -> None:
@@ -1033,20 +945,12 @@ class StreamObject(DictionaryObject):
 
     @property
     def decodedSelf(self) -> Optional["DecodedStreamObject"]:
-        warnings.warn(
-            DEPR_MSG.format("decodedSelf", "decoded_self"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("decodedSelf", "decoded_self")
         return self.decoded_self
 
     @decodedSelf.setter
     def decodedSelf(self, value: "DecodedStreamObject") -> None:
-        warnings.warn(
-            DEPR_MSG.format("decodedSelf", "decoded_self"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("decodedSelf", "decoded_self")
         self.decoded_self = value
 
     @property
@@ -1088,11 +992,7 @@ class StreamObject(DictionaryObject):
         return retval
 
     def flateEncode(self) -> "EncodedStreamObject":
-        warnings.warn(
-            DEPR_MSG.format("flateEncode", "flate_encode"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("flateEncode", "flate_encode")
         return self.flate_encode()
 
     def flate_encode(self) -> "EncodedStreamObject":
@@ -1123,19 +1023,11 @@ class DecodedStreamObject(StreamObject):
         self._data = data
 
     def getData(self) -> Any:
-        warnings.warn(
-            DEPR_MSG.format("decodedSelf", "decoded_self"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getData", "get_data")
         return self._data
 
     def setData(self, data: Any) -> None:
-        warnings.warn(
-            DEPR_MSG.format("decodedSelf", "decoded_self"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("setData", "set_data")
         self.set_data(data)
 
 
@@ -1145,20 +1037,12 @@ class EncodedStreamObject(StreamObject):
 
     @property
     def decodedSelf(self) -> Optional["DecodedStreamObject"]:
-        warnings.warn(
-            DEPR_MSG.format("decodedSelf", "decoded_self"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("decodedSelf", "decoded_self")
         return self.decoded_self
 
     @decodedSelf.setter
     def decodedSelf(self, value: DecodedStreamObject) -> None:
-        warnings.warn(
-            DEPR_MSG.format("decodedSelf", "decoded_self"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("decodedSelf", "decoded_self")
         self.decoded_self = value
 
     def get_data(self) -> Union[None, str, bytes]:
@@ -1387,11 +1271,7 @@ class RectangleObject(ArrayObject):
         return value
 
     def ensureIsNumber(self, value: Any) -> Union[FloatObject, NumberObject]:
-        warnings.warn(
-            DEPR_MSG_NO_REPLACEMENT.format("ensureIsNumber"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_no_replacement("ensureIsNumber")
         return self._ensure_is_number(value)
 
     def __repr__(self) -> str:
@@ -1414,67 +1294,35 @@ class RectangleObject(ArrayObject):
         return self[3]
 
     def getLowerLeft_x(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getLowerLeft_x", "left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getLowerLeft_x", "left")
         return self.left
 
     def getLowerLeft_y(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getLowerLeft_y", "bottom"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getLowerLeft_y", "bottom")
         return self.bottom
 
     def getUpperRight_x(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getUpperRight_x", "right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getUpperRight_x", "right")
         return self.right
 
     def getUpperRight_y(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getUpperRight_y", "top"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getUpperRight_y", "top")
         return self.top
 
     def getUpperLeft_x(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getUpperLeft_x", "left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getUpperLeft_x", "left")
         return self.left
 
     def getUpperLeft_y(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getUpperLeft_y", "top"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getUpperLeft_y", "top")
         return self.top
 
     def getLowerRight_x(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getLowerRight_x", "right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getLowerRight_x", "right")
         return self.right
 
     def getLowerRight_y(self) -> FloatObject:
-        warnings.warn(
-            DEPR_MSG.format("getLowerRight_y", "bottom"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getLowerRight_y", "bottom")
         return self.bottom
 
     @property
@@ -1526,67 +1374,35 @@ class RectangleObject(ArrayObject):
         self[2], self[3] = (self._ensure_is_number(x) for x in value)
 
     def getLowerLeft(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("getLowerLeft", "lower_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getLowerLeft", "lower_left")
         return self.lower_left
 
     def getLowerRight(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("getLowerRight", "lower_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getLowerRight", "lower_right")
         return self.lower_right
 
     def getUpperLeft(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("getUpperLeft", "upper_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getUpperLeft", "upper_left")
         return self.upper_left
 
     def getUpperRight(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("getUpperRight", "upper_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getUpperRight", "upper_right")
         return self.upper_right
 
     def setLowerLeft(self, value: Tuple[float, float]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("setLowerLeft", "lower_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("setLowerLeft", "lower_left")
         self.lower_left = value  # type: ignore
 
     def setLowerRight(self, value: Tuple[float, float]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("setLowerRight", "lower_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("setLowerRight", "lower_right")
         self[2], self[1] = (self._ensure_is_number(x) for x in value)
 
     def setUpperLeft(self, value: Tuple[float, float]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("setUpperLeft", "upper_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("setUpperLeft", "upper_left")
         self[0], self[3] = (self._ensure_is_number(x) for x in value)
 
     def setUpperRight(self, value: Tuple[float, float]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("setUpperRight", "upper_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("setUpperRight", "upper_right")
         self[2], self[3] = (self._ensure_is_number(x) for x in value)
 
     @property
@@ -1594,7 +1410,7 @@ class RectangleObject(ArrayObject):
         return self.right - self.left
 
     def getWidth(self) -> decimal.Decimal:
-        warnings.warn(DEPR_MSG.format("getWidth", "width"), DeprecationWarning)
+        deprecate_with_replacement("getWidth", "width")
         return self.width
 
     @property
@@ -1602,79 +1418,47 @@ class RectangleObject(ArrayObject):
         return self.top - self.bottom
 
     def getHeight(self) -> decimal.Decimal:
-        warnings.warn(DEPR_MSG.format("getHeight", "height"), DeprecationWarning)
+        deprecate_with_replacement("getHeight", "height")
         return self.height
 
     @property
     def lowerLeft(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("lowerLeft", "lower_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("lowerLeft", "lower_left")
         return self.lower_left
 
     @lowerLeft.setter
     def lowerLeft(self, value: Tuple[decimal.Decimal, decimal.Decimal]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("lowerLeft", "lower_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("lowerLeft", "lower_left")
         self.lower_left = value
 
     @property
     def lowerRight(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("lowerRight", "lower_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("lowerRight", "lower_right")
         return self.lower_right
 
     @lowerRight.setter
     def lowerRight(self, value: Tuple[decimal.Decimal, decimal.Decimal]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("lowerRight", "lower_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("lowerRight", "lower_right")
         self.lower_right = value
 
     @property
     def upperLeft(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("upperLeft", "upper_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("upperLeft", "upper_left")
         return self.upper_left
 
     @upperLeft.setter
     def upperLeft(self, value: Tuple[decimal.Decimal, decimal.Decimal]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("upperLeft", "upper_left"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("upperLeft", "upper_left")
         self.upper_left = value
 
     @property
     def upperRight(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        warnings.warn(
-            DEPR_MSG.format("upperRight", "upper_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("upperRight", "upper_right")
         return self.upper_right
 
     @upperRight.setter
     def upperRight(self, value: Tuple[decimal.Decimal, decimal.Decimal]) -> None:
-        warnings.warn(
-            DEPR_MSG.format("upperRight", "upper_right"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("upperRight", "upper_right")
         self.upper_right = value
 
 
@@ -1717,11 +1501,7 @@ class Field(TreeObject):
 
             Use :py:attr:`field_type` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("fieldType", "field_type"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("fieldType", "field_type")
         return self.field_type
 
     @property
@@ -1751,11 +1531,7 @@ class Field(TreeObject):
 
             Use :py:attr:`alternate_name` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("altName", "alternate_name"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("altName", "alternate_name")
         return self.alternate_name
 
     @property
@@ -1774,11 +1550,7 @@ class Field(TreeObject):
 
             Use :py:attr:`mapping_name` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("mappingName", "mapping_name"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("mappingName", "mapping_name")
         return self.mapping_name
 
     @property
@@ -1809,11 +1581,7 @@ class Field(TreeObject):
 
             Use :py:attr:`default_value` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("defaultValue", "default_value"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("defaultValue", "default_value")
         return self.default_value
 
     @property
@@ -1832,11 +1600,7 @@ class Field(TreeObject):
 
             Use :py:attr:`additional_actions` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("additionalActions", "additional_actions"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("additionalActions", "additional_actions")
         return self.additional_actions
 
 
@@ -1925,11 +1689,7 @@ class Destination(TreeObject):
 
             Use :py:attr:`dest_array` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getDestArray", "dest_array"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getDestArray", "dest_array")
         return self.dest_array
 
     def write_to_stream(

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -1,7 +1,6 @@
 import datetime
 import decimal
 import re
-import warnings
 from typing import (
     Any,
     Callable,
@@ -16,7 +15,7 @@ from xml.dom.minidom import Document
 from xml.dom.minidom import Element as XmlElement
 from xml.dom.minidom import parseString
 
-from ._utils import DEPR_MSG, StreamType
+from ._utils import deprecate_with_replacement, StreamType
 from .generic import ContentStream, PdfObject
 
 RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -223,10 +222,7 @@ class XmpInformation(PdfObject):
 
             Use :meth:`write_to_stream` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("writeToStream", "write_to_stream"),
-            PendingDeprecationWarning,
-        )
+        deprecate_with_replacement("writeToStream", "write_to_stream")
         self.write_to_stream(stream, encryption_key)
 
     def get_element(self, about_uri: str, namespace: str, name: str) -> Iterator[Any]:
@@ -243,11 +239,7 @@ class XmpInformation(PdfObject):
 
             Use :meth:`get_element` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getElement", "get_element"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getElement", "get_element")
         return self.get_element(aboutUri, namespace, name)
 
     def get_nodes_in_namespace(self, about_uri: str, namespace: str) -> Iterator[Any]:
@@ -267,11 +259,7 @@ class XmpInformation(PdfObject):
 
             Use :meth:`get_nodes_in_namespace` instead.
         """
-        warnings.warn(
-            DEPR_MSG.format("getNodesInNamespace", "get_nodes_in_namespace"),
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
+        deprecate_with_replacement("getNodesInNamespace", "get_nodes_in_namespace")
         return self.get_nodes_in_namespace(aboutUri, namespace)
 
     def _get_text(self, element: XmlElement) -> str:


### PR DESCRIPTION
PR updates all deprecation warnings in the codebase to go through two wrapper functions, to make it easy to keep the message unified, ensure proper `stacklevel` used, and that the same type of warning is raised, overall ensuring we're not doing a lot of repeating ourselves. All three of those were different in various places across the codebase, leading to a bit of a confusing experience. The wrapper functions were originally accidentally added in #913, though were unused till now.