### PR TITLE
corrected the null evaluation of decoded stream objects.

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1164,7 +1164,7 @@ class EncodedStreamObject(StreamObject):
     def get_data(self) -> Union[None, str, bytes]:
         from .filters import decodeStreamData
 
-        if self.decoded_self:
+        if self.decoded_self is not None:
             # cached version of decoded object
             return self.decoded_self.get_data()
         else:


### PR DESCRIPTION
Under some conditions, the 'if self.decodedSelf' implicit expression
evaluates to 'False' incorrectly.

For example, d = None and d = {} both evaulated to 'False', but in the
updated code only the evaluation of `if d is None` is correct.