### PR TITLE
TST: Ignore PdfReadWarning in benchmark

### DIFF
--- a/tests/bench.py
+++ b/tests/bench.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 import PyPDF2
 from PyPDF2 import PdfReader, Transformation
 from PyPDF2.generic import Destination
@@ -125,6 +127,7 @@ def text_extraction(pdf_path):
     return text
 
 
+@pytest.mark.filterwarnings("ignore::PyPDF2.errors.PdfReadWarning")
 def test_text_extraction(benchmark):
     file = os.path.join(SAMPLE_ROOT, "009-pdflatex-geotopo/GeoTopo.pdf")
     benchmark(text_extraction, file)


### PR DESCRIPTION
Ignore the PdfReadWarning here as this is only supposed to be used
for performance testing.