### PR TITLE
DOC: Fix typo in robustness documentation

### DIFF
--- a/docs/user/robustness.md
+++ b/docs/user/robustness.md
@@ -13,7 +13,7 @@ Python code as an example:
 # Broken
 function (foo, bar):
 
-# Potentially intendet:
+# Potentially intended:
 def function(foo, bar):
     ...
 


### PR DESCRIPTION
Seems a PR from a few days ago missed the typo in the comment just here in the Python example.