### PR TITLE
Add `PageObject` to __init__.py

### DIFF
--- a/PyPDF2/__init__.py
+++ b/PyPDF2/__init__.py
@@ -1,5 +1,5 @@
 from ._merger import PdfFileMerger, PdfMerger
-from ._page import Transformation
+from ._page import Transformation, PageObject
 from ._reader import DocumentInformation, PdfFileReader, PdfReader
 from ._version import __version__
 from ._writer import PdfFileWriter, PdfWriter
@@ -16,7 +16,8 @@ __all__ = [
     "PdfFileReader",  # will be removed in PyPDF2 3.0.0; use PdfReader instead
     "PdfFileWriter",  # will be removed in PyPDF2 3.0.0; use PdfWriter instead
     "PdfMerger",
-    "Transformation",
     "PdfReader",
     "PdfWriter",
+    "Transformation",
+    "PageObject",
 ]


### PR DESCRIPTION
Currently, accessing the `PageObject.create_blank_page` static method depends on importing `PageObject` with something like `from PyPDF2._page import PageObject`. It feels weird as the leading underscore indicates that the `_page` module should not be imported directly.

This PR adds `PageObject` to `__init__.py` allowing it to be imported in a cleaner way with `from PyPDF2 import PageObject`.