### PR TITLE
DOC: add mention of crypto extra_requires for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ You can install PyPDF2 via pip:
 pip install PyPDF2
 ```
 
+If you plan to use PyPDF2 for encrypting or decrypting PDFs that use AES, you
+will need to install some extra dependencies. Encryption using RC4 is supported
+using the regular installation.
+
+```
+pip install PyPDF2[crypto]
+```
+
 ## Usage
 
 ```python

--- a/docs/user/encryption-decryption.md
+++ b/docs/user/encryption-decryption.md
@@ -1,5 +1,9 @@
 # Encryption and Decryption of PDFs
 
+Please see the note in the
+[Installation doc](https://pypdf2.readthedocs.io/en/latest/user/installation.html)
+for installing the extra dependencies if interacting with PDFs that use AES.
+
 ## Encrypt
 
 Add a password to a PDF (encrypt it):

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -20,6 +20,14 @@ install PyPDF2 for your current user:
 pip install --user PyPDF2
 ```
 
+If you plan to use PyPDF2 for encrypting or decrypting PDFs that use AES, you
+will need to install some extra dependencies. Encryption using RC4 is supported
+using the regular installation.
+
+```
+pip install PyPDF2[crypto]
+```
+
 ## Anaconda
 
 Anaconda users can [install PyPDF2 via conda-forge](https://anaconda.org/conda-forge/pypdf2).


### PR DESCRIPTION
This PR updates the docs to make mention of the `PyPDF2[crypto]` extras package when interacting with AES encrypted PDFs.