### PR TITLE
STY: Docstring formatting

### DIFF
--- a/PyPDF2/_encryption.py
+++ b/PyPDF2/_encryption.py
@@ -25,10 +25,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from enum import IntEnum
 import hashlib
 import random
 import struct
+from enum import IntEnum
 from typing import Optional, Tuple, Union, cast
 
 from PyPDF2.errors import DependencyError
@@ -239,32 +239,47 @@ class AlgV4:
         metadata_encrypted: bool,
     ) -> bytes:
         """
-        Algorithm 2: Computing an encryption key
+        Algorithm 2: Computing an encryption key.
 
-        a) Pad or truncate the password string to exactly 32 bytes. If the password string is more than 32 bytes long,
-           use only its first 32 bytes; if it is less than 32 bytes long, pad it by appending the required number of
+        a) Pad or truncate the password string to exactly 32 bytes. If the
+           password string is more than 32 bytes long,
+           use only its first 32 bytes; if it is less than 32 bytes long, pad it
+           by appending the required number of
            additional bytes from the beginning of the following padding string:
                 < 28 BF 4E 5E 4E 75 8A 41 64 00 4E 56 FF FA 01 08
                 2E 2E 00 B6 D0 68 3E 80 2F 0C A9 FE 64 53 69 7A >
-           That is, if the password string is n bytes long, append the first 32 - n bytes of the padding string to the end
-           of the password string. If the password string is empty (zero-length), meaning there is no user password,
+           That is, if the password string is n bytes long, append
+           the first 32 - n bytes of the padding string to the end
+           of the password string. If the password string is empty (zero-length),
+           meaning there is no user password,
            substitute the entire padding string in its place.
 
-        b) Initialize the MD5 hash function and pass the result of step (a) as input to this function.
-        c) Pass the value of the encryption dictionary’s O entry to the MD5 hash function. ("Algorithm 3: Computing
-           the encryption dictionary’s O (owner password) value" shows how the O value is computed.)
-        d) Convert the integer value of the P entry to a 32-bit unsigned binary number and pass these bytes to the
+        b) Initialize the MD5 hash function and pass the result of step (a)
+           as input to this function.
+        c) Pass the value of the encryption dictionary’s O entry to the
+           MD5 hash function. ("Algorithm 3: Computing
+           the encryption dictionary’s O (owner password) value" shows how the
+           O value is computed.)
+        d) Convert the integer value of the P entry to a 32-bit unsigned binary
+           number and pass these bytes to the
            MD5 hash function, low-order byte first.
-        e) Pass the first element of the file’s file identifier array (the value of the ID entry in the document’s trailer
+        e) Pass the first element of the file’s file identifier array (the value
+           of the ID entry in the document’s trailer
            dictionary; see Table 15) to the MD5 hash function.
-        f) (Security handlers of revision 4 or greater) If document metadata is not being encrypted, pass 4 bytes with
+        f) (Security handlers of revision 4 or greater) If document metadata is
+           not being encrypted, pass 4 bytes with
            the value 0xFFFFFFFF to the MD5 hash function.
         g) Finish the hash.
-        h) (Security handlers of revision 3 or greater) Do the following 50 times: Take the output from the previous
-           MD5 hash and pass the first n bytes of the output as input into a new MD5 hash, where n is the number of
-           bytes of the encryption key as defined by the value of the encryption dictionary’s Length entry.
-        i) Set the encryption key to the first n bytes of the output from the final MD5 hash, where n shall always be 5
-           for security handlers of revision 2 but, for security handlers of revision 3 or greater, shall depend on the
+        h) (Security handlers of revision 3 or greater) Do the following
+           50 times: Take the output from the previous
+           MD5 hash and pass the first n bytes of the output as input into a new
+           MD5 hash, where n is the number of
+           bytes of the encryption key as defined by the value of the encryption
+           dictionary’s Length entry.
+        i) Set the encryption key to the first n bytes of the output from the
+           final MD5 hash, where n shall always be 5
+           for security handlers of revision 2 but, for security handlers of
+           revision 3 or greater, shall depend on the
            value of the encryption dictionary’s Length entry.
         """
         a = _padding(password)
@@ -284,26 +299,36 @@ class AlgV4:
     @staticmethod
     def compute_O_value_key(owner_pwd: bytes, rev: int, key_size: int) -> bytes:
         """
-        Algorithm 3: Computing the encryption dictionary’s O (owner password) value
+        Algorithm 3: Computing the encryption dictionary’s O (owner password) value.
 
-        a) Pad or truncate the owner password string as described in step (a) of "Algorithm 2: Computing an
-           encryption key". If there is no owner password, use the user password instead.
-        b) Initialize the MD5 hash function and pass the result of step (a) as input to this function.
-        c) (Security handlers of revision 3 or greater) Do the following 50 times: Take the output from the previous
+        a) Pad or truncate the owner password string as described in step (a)
+           of "Algorithm 2: Computing an encryption key".
+           If there is no owner password, use the user password instead.
+        b) Initialize the MD5 hash function and pass the result of step (a) as
+           input to this function.
+        c) (Security handlers of revision 3 or greater) Do the following 50 times:
+           Take the output from the previous
            MD5 hash and pass it as input into a new MD5 hash.
-        d) Create an RC4 encryption key using the first n bytes of the output from the final MD5 hash, where n shall
-           always be 5 for security handlers of revision 2 but, for security handlers of revision 3 or greater, shall
+        d) Create an RC4 encryption key using the first n bytes of the output
+           from the final MD5 hash, where n shall
+           always be 5 for security handlers of revision 2 but, for security
+           handlers of revision 3 or greater, shall
            depend on the value of the encryption dictionary’s Length entry.
-        e) Pad or truncate the user password string as described in step (a) of "Algorithm 2: Computing an encryption key".
-        f) Encrypt the result of step (e), using an RC4 encryption function with the encryption key obtained in step (d).
-        g) (Security handlers of revision 3 or greater) Do the following 19 times: Take the output from the previous
-           invocation of the RC4 function and pass it as input to a new invocation of the function; use an encryption
-           key generated by taking each byte of the encryption key obtained in step (d) and performing an XOR
-           (exclusive or) operation between that byte and the single-byte value of the iteration counter (from 1 to 19).
-        h) Store the output from the final invocation of the RC4 function as the value of the O entry in the encryption
-           dictionary.
+        e) Pad or truncate the user password string as described in step (a) of
+           "Algorithm 2: Computing an encryption key".
+        f) Encrypt the result of step (e), using an RC4 encryption function with
+           the encryption key obtained in step (d).
+        g) (Security handlers of revision 3 or greater) Do the following 19 times:
+           Take the output from the previous
+           invocation of the RC4 function and pass it as input to a new
+           invocation of the function; use an encryption
+           key generated by taking each byte of the encryption key obtained in
+           step (d) and performing an XOR
+           (exclusive or) operation between that byte and the single-byte value
+           of the iteration counter (from 1 to 19).
+        h) Store the output from the final invocation of the RC4 function as
+           the value of the O entry in the encryption dictionary.
         """
-
         a = _padding(owner_pwd)
         o_hash_digest = hashlib.md5(a).digest()
 
@@ -316,7 +341,7 @@ class AlgV4:
 
     @staticmethod
     def compute_O_value(rc4_key: bytes, user_pwd: bytes, rev: int) -> bytes:
-        """see :func:`compute_O_value_key`"""
+        """See :func:`compute_O_value_key`."""
         a = _padding(user_pwd)
         rc4_enc = RC4_encrypt(rc4_key, a)
         if rev >= 3:
@@ -328,34 +353,46 @@ class AlgV4:
     @staticmethod
     def compute_U_value(key: bytes, rev: int, id1_entry: bytes) -> bytes:
         """
-        Algorithm 4: Computing the encryption dictionary’s U (user password) value (Security handlers of revision 2)
+        Algorithm 4: Computing the encryption dictionary’s U (user password) value.
 
-        a) Create an encryption key based on the user password string, as described in "Algorithm 2: Computing an
-           encryption key".
-        b) Encrypt the 32-byte padding string shown in step (a) of "Algorithm 2: Computing an encryption key", using
-           an RC4 encryption function with the encryption key from the preceding step.
-        c) Store the result of step (b) as the value of the U entry in the encryption dictionary.
+        (Security handlers of revision 2)
+
+        a) Create an encryption key based on the user password string, as
+           described in "Algorithm 2: Computing an encryption key".
+        b) Encrypt the 32-byte padding string shown in step (a) of
+           "Algorithm 2: Computing an encryption key", using an RC4 encryption
+           function with the encryption key from the preceding step.
+        c) Store the result of step (b) as the value of the U entry in the
+           encryption dictionary.
         """
         if rev <= 2:
             value = RC4_encrypt(key, _PADDING)
             return value
 
         """
-        Algorithm 5: Computing the encryption dictionary’s U (user password) value (Security handlers of revision 3 or greater)
+        Algorithm 5: Computing the encryption dictionary’s U (user password) value.
 
-        a) Create an encryption key based on the user password string, as described in "Algorithm 2: Computing an
-           encryption key".
-        b) Initialize the MD5 hash function and pass the 32-byte padding string shown in step (a) of "Algorithm 2:
+        (Security handlers of revision 3 or greater)
+
+        a) Create an encryption key based on the user password string, as
+           described in "Algorithm 2: Computing an encryption key".
+        b) Initialize the MD5 hash function and pass the 32-byte padding string
+           shown in step (a) of "Algorithm 2:
            Computing an encryption key" as input to this function.
-        c) Pass the first element of the file’s file identifier array (the value of the ID entry in the document’s trailer
+        c) Pass the first element of the file’s file identifier array (the value
+           of the ID entry in the document’s trailer
            dictionary; see Table 15) to the hash function and finish the hash.
-        d) Encrypt the 16-byte result of the hash, using an RC4 encryption function with the encryption key from step (a).
-        e) Do the following 19 times: Take the output from the previous invocation of the RC4 function and pass it as
-           input to a new invocation of the function; use an encryption key generated by taking each byte of the
-           original encryption key obtained in step (a) and performing an XOR (exclusive or) operation between that
+        d) Encrypt the 16-byte result of the hash, using an RC4 encryption
+           function with the encryption key from step (a).
+        e) Do the following 19 times: Take the output from the previous
+           invocation of the RC4 function and pass it as input to a new
+           invocation of the function; use an encryption key generated by
+           taking each byte of the original encryption key obtained in
+           step (a) and performing an XOR (exclusive or) operation between that
            byte and the single-byte value of the iteration counter (from 1 to 19).
-        f) Append 16 bytes of arbitrary padding to the output from the final invocation of the RC4 function and store
-           the 32-byte result as the value of the U entry in the encryption dictionary.
+        f) Append 16 bytes of arbitrary padding to the output from the final
+           invocation of the RC4 function and store the 32-byte result as the
+           value of the U entry in the encryption dictionary.
         """
         u_hash = hashlib.md5(_PADDING)
         u_hash.update(id1_entry)
@@ -377,7 +414,7 @@ class AlgV4:
         metadata_encrypted: bool,
     ) -> bytes:
         """
-        Algorithm 6: Authenticating the user password
+        Algorithm 6: Authenticating the user password.
 
         a) Perform all but the last step of "Algorithm 4: Computing the encryption dictionary’s U (user password)
            value (Security handlers of revision 2)" or "Algorithm 5: Computing the encryption dictionary’s U (user
@@ -412,7 +449,7 @@ class AlgV4:
         metadata_encrypted: bool,
     ) -> bytes:
         """
-        Algorithm 7: Authenticating the owner password
+        Algorithm 7: Authenticating the owner password.
 
         a) Compute an encryption key from the supplied password string, as described in steps (a) to (d) of
            "Algorithm 3: Computing the encryption dictionary’s O (owner password) value".
@@ -446,7 +483,7 @@ class AlgV5:
         R: int, password: bytes, o_value: bytes, oe_value: bytes, u_value: bytes
     ) -> bytes:
         """
-        Algorithm 3.2a Computing an encryption key
+        Algorithm 3.2a Computing an encryption key.
 
         To understand the algorithm below, it is necessary to treat the O and U strings in the Encrypt dictionary
         as made up of three sections. The first 32 bytes are a hash value (explained below). The next 8 bytes are
@@ -483,8 +520,10 @@ class AlgV5:
         return key
 
     @staticmethod
-    def verify_user_password(R: int, password: bytes, u_value: bytes, ue_value: bytes) -> bytes:
-        """see :func:`verify_owner_password`"""
+    def verify_user_password(
+        R: int, password: bytes, u_value: bytes, ue_value: bytes
+    ) -> bytes:
+        """See :func:`verify_owner_password`."""
         password = password[:127]
         if AlgV5.calculate_hash(R, password, u_value[32:40], b"") != u_value[:32]:
             return b""
@@ -517,7 +556,7 @@ class AlgV5:
     def verify_perms(
         key: bytes, perms: bytes, p: int, metadata_encrypted: bool
     ) -> bool:
-        """see :func:`verify_owner_password` and :func:`compute_Perms_value`"""
+        """See :func:`verify_owner_password` and :func:`compute_Perms_value`."""
         b8 = b"T" if metadata_encrypted else b"F"
         p1 = struct.pack("<I", p) + b"\xff\xff\xff\xff" + b8 + b"adb"
         p2 = AES_ECB_decrypt(key, perms)
@@ -566,7 +605,7 @@ class AlgV5:
         password: bytes, key: bytes, u_value: bytes
     ) -> Tuple[bytes, bytes]:
         """
-        Algorithm 3.9 Computing the encryption dictionary’s O (owner password) and OE (owner encryption key) values
+        Algorithm 3.9 Computing the encryption dictionary’s O (owner password) and OE (owner encryption key) values.
 
         1. Generate 16 random bytes of data using a strong random number generator. The first 8 bytes are the
            Owner Validation Salt. The second 8 bytes are the Owner Key Salt. Compute the 32-byte SHA-256 hash
@@ -649,7 +688,7 @@ class Encryption:
 
     def decrypt_object(self, obj: PdfObject, idnum: int, generation: int) -> PdfObject:
         """
-        Algorithm 1: Encryption of data using the RC4 or AES algorithms
+        Algorithm 1: Encryption of data using the RC4 or AES algorithms.
 
         a) Obtain the object number and generation number from the object identifier of the string or stream to be
            encrypted (see 7.3.10, "Indirect Objects"). If the string is a direct object, use the identifier of the indirect
@@ -771,7 +810,9 @@ class Encryption:
         ue_entry = cast(ByteStringObject, self.entry["/UE"].get_object()).original_bytes
 
         # verify owner password first
-        key = AlgV5.verify_owner_password(self.algR, password, o_entry, oe_entry, u_entry)
+        key = AlgV5.verify_owner_password(
+            self.algR, password, o_entry, oe_entry, u_entry
+        )
         rc = PasswordType.OWNER_PASSWORD
         if not key:
             key = AlgV5.verify_user_password(self.algR, password, u_entry, ue_entry)

--- a/PyPDF2/_merger.py
+++ b/PyPDF2/_merger.py
@@ -61,10 +61,7 @@ ERR_CLOSED_WRITER = "close() was called and thus the writer cannot be used anymo
 
 
 class _MergedPage:
-    """
-    _MergedPage is used internally by PdfMerger to collect necessary
-    information on each page that is being merged.
-    """
+    """Collect necessary information on each page that is being merged."""
 
     def __init__(self, pagedata: PageObject, src: PdfReader, id: int) -> None:
         self.src = src
@@ -75,9 +72,10 @@ class _MergedPage:
 
 class PdfMerger:
     """
-    Initializes a ``PdfMerger`` object. ``PdfMerger`` merges multiple
-    PDFs into a single PDF. It can concatenate, slice, insert, or any
-    combination of the above.
+    Initialize a ``PdfMerger`` object.
+
+    ``PdfMerger`` merges multiple PDFs into a single PDF.
+    It can concatenate, slice, insert, or any combination of the above.
 
     See the functions :meth:`merge()<merge>` (or :meth:`append()<append>`)
     and :meth:`write()<write>` for usage information.
@@ -105,7 +103,7 @@ class PdfMerger:
         import_bookmarks: bool = True,
     ) -> None:
         """
-        Merges the pages from the given file into the output file at the
+        Merge the pages from the given file into the output file at the
         specified page number.
 
         :param int position: The *page number* to insert this file. File will
@@ -127,7 +125,6 @@ class PdfMerger:
         :param bool import_bookmarks: You may prevent the source document's
             bookmarks from being imported by specifying this as ``False``.
         """
-
         stream, my_file, encryption_obj = self._create_stream(fileobj)
 
         # Create a new PdfReader instance using the stream
@@ -253,7 +250,7 @@ class PdfMerger:
 
     def write(self, fileobj: StrByteType) -> None:
         """
-        Writes all data that has been merged to the given output file.
+        Write all data that has been merged to the given output file.
 
         :param fileobj: Output file. Can be a filename or any kind of
             file-like object.
@@ -288,10 +285,7 @@ class PdfMerger:
             fileobj.close()
 
     def close(self) -> None:
-        """
-        Shuts all file descriptors (input and output) and clears all memory
-        usage.
-        """
+        """Shut all file descriptors (input and output) and clear all memory usage."""
         self.pages = []
         for fo, _reader, mine in self.inputs:
             if mine:
@@ -332,7 +326,7 @@ class PdfMerger:
 
     def set_page_layout(self, layout: LayoutType) -> None:
         """
-        Set the page layout
+        Set the page layout.
 
         :param str layout: The page layout to be used
 
@@ -399,10 +393,7 @@ class PdfMerger:
         dests: Dict[str, Dict[str, Any]],
         pages: Union[Tuple[int, int], Tuple[int, int, int]],
     ) -> List[Dict[str, Any]]:
-        """
-        Removes any named destinations that are not a part of the specified
-        page set.
-        """
+        """Remove named destinations that are not a part of the specified page set."""
         new_dests = []
         for key, obj in dests.items():
             for j in range(*pages):
@@ -419,10 +410,7 @@ class PdfMerger:
         outline: OutlinesType,
         pages: Union[Tuple[int, int], Tuple[int, int, int]],
     ) -> OutlinesType:
-        """
-        Removes any outline/bookmark entries that are not a part of the
-        specified page set.
-        """
+        """Remove outline/bookmark entries that are not a part of the specified page set."""
         new_outline = []
         prev_header_added = True
         for i, o in enumerate(outline):
@@ -680,7 +668,6 @@ class PdfMerger:
         :param str title: Title to use
         :param int pagenum: Page number this destination points at.
         """
-
         dest = Destination(
             TextStringObject(title),
             NumberObject(pagenum),

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -1118,7 +1118,6 @@ class PageObject(DictionaryObject):
             default = "/Content"
         :return: a string object.
         """
-
         text: str = ""
         output: str = ""
         cmaps: Dict[
@@ -1316,7 +1315,8 @@ class PageObject(DictionaryObject):
         self, xform: EncodedStreamObject, space_width: float = 200.0
     ) -> str:
         """
-        Extraction tet from an XObject.
+        Extraction text from an XObject.
+
         space_width : float = force default space width (if not extracted from font (default 200)
 
         :return: a string object.

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -1315,7 +1315,7 @@ class PageObject(DictionaryObject):
         self, xform: EncodedStreamObject, space_width: float = 200.0
     ) -> str:
         """
-        Extraction text from an XObject.
+        Extract text from an XObject.
 
         space_width : float = force default space width (if not extracted from font (default 200)
 

--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -260,8 +260,7 @@ class PageObject(DictionaryObject):
             space units.
         :param float height: The height of the new page expressed in default user
             space units.
-        :return: the new blank page:
-        :rtype: :class:`PageObject<PageObject>`
+        :return: the new blank page
         :raises PageSizeNotDefinedError: if ``pdf`` is ``None`` or contains
             no page
         """
@@ -1300,14 +1299,18 @@ class PageObject(DictionaryObject):
     ) -> str:
         """
         Locate all text drawing commands, in the order they are provided in the
-        content stream, and extract the text.  This works well for some PDF
-        files, but poorly for others, depending on the generator used.  This will
-        be refined in the future.  Do not rely on the order of text coming out of
-        this function, as it will change if this function is made more
-        sophisticated.
-        space_width : float = force default space width (if not extracted from font (default 200)
+        content stream, and extract the text.
 
-        :return: a string object.
+        This works well for some PDF files, but poorly for others, depending on
+        the generator used.  This will be refined in the future.
+
+        Do not rely on the order of text coming out of this function, as it
+        will change if this function is made more sophisticated.
+
+
+        :param space_width : force default space width (if not extracted from font (default 200)
+
+        :return: The extracted text
         """
         return self._extract_text(self, self.pdf, space_width, PG.CONTENTS)
 
@@ -1319,7 +1322,7 @@ class PageObject(DictionaryObject):
 
         space_width : float = force default space width (if not extracted from font (default 200)
 
-        :return: a string object.
+        :return: The extracted text
         """
         return self._extract_text(xform, self.pdf, space_width, None)
 

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -308,8 +308,6 @@ class PdfReader:
         function.
 
         :return: the document information of this PDF file
-        :rtype: :class:`DocumentInformation<pdf.DocumentInformation>` or
-            ``None`` if none exists.
         """
         if TK.INFO not in self.trailer:
             return None
@@ -344,8 +342,7 @@ class PdfReader:
 
         :return: a :class:`XmpInformation<xmp.XmpInformation>`
             instance that can be used to access XMP metadata from the document.
-        :rtype: :class:`XmpInformation<xmp.XmpInformation>` or
-            ``None`` if no metadata was found on the document root.
+            or ``None`` if no metadata was found on the document root.
         """
         try:
             self._override_encryption = True
@@ -377,7 +374,6 @@ class PdfReader:
         Calculate the number of pages in this PDF file.
 
         :return: number of pages
-        :rtype: int
         :raises PdfReadError: if file is encrypted and restrictions prevent
             this action.
         """
@@ -428,7 +424,6 @@ class PdfReader:
         :param int page_number: The page number to retrieve
             (pages begin at zero)
         :return: a :class:`PageObject<PyPDF2._page.PageObject>` instance.
-        :rtype: :class:`PageObject<PyPDF2._page.PageObject>`
         """
         # ensure that we're not trying to access an encrypted PDF
         # assert not self.trailer.has_key(TK.ENCRYPT)
@@ -474,7 +469,7 @@ class PdfReader:
         :return: A dictionary where each key is a field name, and each
             value is a :class:`Field<PyPDF2.generic.Field>` object. By
             default, the mapping name is used for keys.
-        :rtype: dict, or ``None`` if form data could not be located.
+            ``None`` if form data could not be located.
         """
         field_attributes = {
             "/FT": "Field Type",
@@ -622,7 +617,6 @@ class PdfReader:
 
         :return: a dictionary which maps names to
             :class:`Destinations<PyPDF2.generic.Destination>`.
-        :rtype: dict
         """
         if retval is None:
             retval = {}
@@ -761,7 +755,6 @@ class PdfReader:
         :param PageObject page: The page to get page number. Should be
             an instance of :class:`PageObject<PyPDF2._page.PageObject>`
         :return: the page number or -1 if page not found
-        :rtype: int
         """
         return self._get_page_number_by_indirect(page.indirect_ref)
 
@@ -780,7 +773,6 @@ class PdfReader:
 
         :param Destination destination: The destination to get page number.
         :return: the page number or -1 if page not found
-        :rtype: int
         """
         return self._get_page_number_by_indirect(destination.page)
 
@@ -855,7 +847,6 @@ class PdfReader:
         Get the page layout.
 
         :return: Page layout currently being used.
-        :rtype: ``str``, ``None`` if not specified
 
         .. list-table:: Valid ``layout`` values
            :widths: 50 200
@@ -905,7 +896,6 @@ class PdfReader:
         Get the page mode.
 
         :return: Page mode currently being used.
-        :rtype: ``str``, ``None`` if not specified
 
         .. list-table:: Valid ``mode`` values
            :widths: 50 200
@@ -1600,8 +1590,6 @@ class PdfReader:
 
         :param str password: The password to match.
         :return: `PasswordType`.
-        :rtype: int
-            method.
         """
         if not self._encryption:
             raise PdfReadError("Not encrypted file")

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -66,11 +66,7 @@ from .constants import DocumentInformationAttributes as DI
 from .constants import PageAttributes as PG
 from .constants import PagesAttributes as PA
 from .constants import TrailerKeys as TK
-from .errors import (
-    PdfReadError,
-    PdfReadWarning,
-    PdfStreamError,
-)
+from .errors import PdfReadError, PdfReadWarning, PdfStreamError
 from .generic import (
     ArrayObject,
     ContentStream,
@@ -143,9 +139,12 @@ class DocumentInformation(DictionaryObject):
 
     @property
     def title(self) -> Optional[str]:
-        """Read-only property accessing the document's **title**.
+        """
+        Read-only property accessing the document's **title**.
+
         Returns a unicode string (``TextStringObject``) or ``None``
-        if the title is not specified."""
+        if the title is not specified.
+        """
         return (
             self._get_text(DI.TITLE) or self.get(DI.TITLE).get_object()  # type: ignore
             if self.get(DI.TITLE)
@@ -159,9 +158,12 @@ class DocumentInformation(DictionaryObject):
 
     @property
     def author(self) -> Optional[str]:
-        """Read-only property accessing the document's **author**.
+        """
+        Read-only property accessing the document's **author**.
+
         Returns a unicode string (``TextStringObject``) or ``None``
-        if the author is not specified."""
+        if the author is not specified.
+        """
         return self._get_text(DI.AUTHOR)
 
     @property
@@ -171,9 +173,12 @@ class DocumentInformation(DictionaryObject):
 
     @property
     def subject(self) -> Optional[str]:
-        """Read-only property accessing the document's **subject**.
+        """
+        Read-only property accessing the document's **subject**.
+
         Returns a unicode string (``TextStringObject``) or ``None``
-        if the subject is not specified."""
+        if the subject is not specified.
+        """
         return self._get_text(DI.SUBJECT)
 
     @property
@@ -183,11 +188,14 @@ class DocumentInformation(DictionaryObject):
 
     @property
     def creator(self) -> Optional[str]:
-        """Read-only property accessing the document's **creator**. If the
-        document was converted to PDF from another format, this is the name of the
-        application (e.g. OpenOffice) that created the original document from
-        which it was converted. Returns a unicode string (``TextStringObject``)
-        or ``None`` if the creator is not specified."""
+        """
+        Read-only property accessing the document's **creator**.
+
+        If the document was converted to PDF from another format, this is the
+        name of the application (e.g. OpenOffice) that created the original
+        document from which it was converted. Returns a unicode string
+        (``TextStringObject``) or ``None`` if the creator is not specified.
+        """
         return self._get_text(DI.CREATOR)
 
     @property
@@ -197,11 +205,14 @@ class DocumentInformation(DictionaryObject):
 
     @property
     def producer(self) -> Optional[str]:
-        """Read-only property accessing the document's **producer**.
+        """
+        Read-only property accessing the document's **producer**.
+
         If the document was converted to PDF from another format, this is
         the name of the application (for example, OSX Quartz) that converted
         it to PDF. Returns a unicode string (``TextStringObject``)
-        or ``None`` if the producer is not specified."""
+        or ``None`` if the producer is not specified.
+        """
         return self._get_text(DI.PRODUCER)
 
     @property
@@ -262,12 +273,17 @@ class PdfReader:
             # https://github.com/mstamy2/PyPDF2/issues/608
             id_entry = self.trailer.get(TK.ID)
             id1_entry = id_entry[0].get_object().original_bytes if id_entry else b""
-            encrypt_entry = cast(DictionaryObject, self.trailer[TK.ENCRYPT].get_object())
+            encrypt_entry = cast(
+                DictionaryObject, self.trailer[TK.ENCRYPT].get_object()
+            )
             self._encryption = Encryption.read(encrypt_entry, id1_entry)
 
             # try empty password if no password provided
             pwd = password if password is not None else b""
-            if self._encryption.verify(pwd) == PasswordType.NOT_DECRYPTED and password is not None:
+            if (
+                self._encryption.verify(pwd) == PasswordType.NOT_DECRYPTED
+                and password is not None
+            ):
                 # raise if password provided
                 raise PdfReadError("Wrong password")
             self._override_encryption = False
@@ -358,14 +374,13 @@ class PdfReader:
 
     def _get_num_pages(self) -> int:
         """
-        Calculates the number of pages in this PDF file.
+        Calculate the number of pages in this PDF file.
 
         :return: number of pages
         :rtype: int
         :raises PdfReadError: if file is encrypted and restrictions prevent
             this action.
         """
-
         # Flattened pages will not work on an Encrypted PDF;
         # the PDF file's page count is used in this case. Otherwise,
         # the original method (flattened page count) is used.
@@ -408,7 +423,7 @@ class PdfReader:
 
     def _get_page(self, page_number: int) -> PageObject:
         """
-        Retrieves a page by number from this PDF file.
+        Retrieve a page by number from this PDF file.
 
         :param int page_number: The page number to retrieve
             (pages begin at zero)
@@ -450,7 +465,8 @@ class PdfReader:
         fileobj: Optional[Any] = None,
     ) -> Optional[Dict[str, Any]]:
         """
-        Extracts field data if this PDF contains interactive form fields.
+        Extract field data if this PDF contains interactive form fields.
+
         The *tree* and *retval* parameters are for recursive use.
 
         :param fileobj: A file object (usually a text file) to write
@@ -569,7 +585,7 @@ class PdfReader:
 
     def get_form_text_fields(self) -> Dict[str, Any]:
         """
-        Retrieves form fields from the document with textual data.
+        Retrieve form fields from the document with textual data.
 
         The key is the name of the form field, the value is the content of the
         field.
@@ -602,7 +618,7 @@ class PdfReader:
         retval: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
-        Retrieves the named destinations present in the document.
+        Retrieve the named destinations present in the document.
 
         :return: a dictionary which maps names to
             :class:`Destinations<PyPDF2.generic.Destination>`.

--- a/PyPDF2/_security.py
+++ b/PyPDF2/_security.py
@@ -54,8 +54,9 @@ def _alg32(
     metadata_encrypt: bool = True,
 ) -> bytes:
     """
-    Implementation of algorithm 3.2 of the PDF standard security handler,
-    section 3.5.2 of the PDF 1.6 reference.
+    Implementation of algorithm 3.2 of the PDF standard security handler.
+
+    See section 3.5.2 of the PDF 1.6 reference.
     """
     # 1. Pad or truncate the password string to exactly 32 bytes.  If the
     # password string is more than 32 bytes long, use only its first 32 bytes;
@@ -159,8 +160,9 @@ def _alg34(
     id1_entry: ByteStringObject,
 ) -> Tuple[bytes, bytes]:
     """
-    Implementation of algorithm 3.4 of the PDF standard security handler,
-    section 3.5.2 of the PDF 1.6 reference.
+    Implementation of algorithm 3.4 of the PDF standard security handler.
+
+    See section 3.5.2 of the PDF 1.6 reference.
     """
     # 1. Create an encryption key based on the user password string, as
     # described in algorithm 3.2.
@@ -186,8 +188,9 @@ def _alg35(
     metadata_encrypt: bool,
 ) -> Tuple[bytes, bytes]:
     """
-    Implementation of algorithm 3.4 of the PDF standard security handler,
-    section 3.5.2 of the PDF 1.6 reference.
+    Implementation of algorithm 3.4 of the PDF standard security handler.
+
+    See section 3.5.2 of the PDF 1.6 reference.
     """
     # 1. Create an encryption key based on the user password string, as
     # described in Algorithm 3.2.

--- a/PyPDF2/_utils.py
+++ b/PyPDF2/_utils.py
@@ -25,9 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""
-Utility functions for PDF library.
-"""
+"""Utility functions for PDF library."""
 __author__ = "Mathieu Fenniak"
 __author_email__ = "biziqe@mathieu.fenniak.net"
 
@@ -68,7 +66,8 @@ DEPR_MSG = "{} is deprecated and will be removed in PyPDF2 3.0.0. Use {} instead
 
 def read_until_whitespace(stream: StreamType, maxchars: Optional[int] = None) -> bytes:
     """
-    Reads non-whitespace characters and returns them.
+    Read non-whitespace characters and return them.
+
     Stops upon encountering whitespace or when maxchars is reached.
     """
     txt = b""
@@ -83,9 +82,7 @@ def read_until_whitespace(stream: StreamType, maxchars: Optional[int] = None) ->
 
 
 def read_non_whitespace(stream: StreamType) -> bytes:
-    """
-    Finds and reads the next non-whitespace character (ignores whitespace).
-    """
+    """Find and read the next non-whitespace character (ignores whitespace)."""
     tok = stream.read(1)
     while tok in WHITESPACES:
         tok = stream.read(1)
@@ -94,7 +91,7 @@ def read_non_whitespace(stream: StreamType) -> bytes:
 
 def skip_over_whitespace(stream: StreamType) -> bool:
     """
-    Similar to readNonWhitespace, but returns a Boolean if more than
+    Similar to read_non_whitespace, but return a Boolean if more than
     one whitespace character was read.
     """
     tok = WHITESPACES[0]
@@ -117,7 +114,8 @@ def read_until_regex(
     stream: StreamType, regex: Pattern, ignore_eof: bool = False
 ) -> bytes:
     """
-    Reads until the regular expression pattern matched (ignore the match)
+    Read until the regular expression pattern matched (ignore the match).
+
     :raises PdfStreamError: on premature end-of-file
     :param bool ignore_eof: If true, ignore end-of-line and return immediately
     :param regex: re.Pattern
@@ -156,8 +154,10 @@ def read_block_backwards(stream: StreamType, to_read: int) -> bytes:
 
 
 def read_previous_line(stream: StreamType) -> bytes:
-    """Given a byte stream with current position X, return the previous
-    line - all characters between the first CR/LF byte found before X
+    """
+    Given a byte stream with current position X, return the previous line.
+
+    All characters between the first CR/LF byte found before X
     (or, the start of the file, if no such byte is found) and position X
     After this call, the stream will be positioned one byte after the
     first non-CRLF character found beyond the first CR/LF byte before X,
@@ -214,7 +214,7 @@ def matrix_multiply(
 
 
 def mark_location(stream: StreamType) -> None:
-    """Creates text file showing current location in context."""
+    """Create text file showing current location in context."""
     # Mainly for debugging
     radius = 5000
     stream.seek(-radius, 1)

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -178,8 +178,10 @@ class PdfWriter:
 
     def add_page(self, page: PageObject) -> None:
         """
-        Add a page to this PDF file.  The page is usually acquired from a
-        :class:`PdfReader<PyPDF2.PdfReader>` instance.
+        Add a page to this PDF file.
+
+        The page is usually acquired from a :class:`PdfReader<PyPDF2.PdfReader>`
+        instance.
 
         :param PageObject page: The page to add to the document. Should be
             an instance of :class:`PageObject<PyPDF2._page.PageObject>`
@@ -250,10 +252,6 @@ class PdfWriter:
         return self.get_page(pageNumber)
 
     def _get_num_pages(self) -> int:
-        """
-        :return: the number of pages.
-        :rtype: int
-        """
         pages = cast(Dict[str, Any], self.get_object(self._pages))
         return int(pages[NameObject("/Count")])
 
@@ -268,9 +266,7 @@ class PdfWriter:
 
     @property
     def pages(self) -> List[PageObject]:
-        """
-        Property that emulates a list of :class:`PageObject<PyPDF2._page.PageObject>`
-        """
+        """Property that emulates a list of :class:`PageObject<PyPDF2._page.PageObject>`."""
         return _VirtualList(self._get_num_pages, self.get_page)  # type: ignore
 
     def add_blank_page(
@@ -539,6 +535,7 @@ class PdfWriter:
     ) -> None:
         """
         Update the form field values for a given page from a fields dictionary.
+
         Copy field texts and values from fields to page.
         If the field links to a parent object, add the information to the parent.
 
@@ -1350,7 +1347,6 @@ class PdfWriter:
             properties. See the PDF spec for details. No border will be
             drawn if this argument is omitted.
         """
-
         page_link = self.get_object(self._pages)[PA.KIDS][pagenum]  # type: ignore
         page_ref = cast(Dict[str, Any], self.get_object(page_link))
 

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -226,7 +226,6 @@ class PdfWriter:
         :param int page_number: The page number to retrieve
             (pages begin at zero)
         :return: the page at the index given by *page_number*
-        :rtype: :class:`PageObject<PyPDF2._page.PageObject>`
         """
         if pageNumber is not None:  # pragma: no cover
             if page_number is not None:
@@ -281,7 +280,6 @@ class PdfWriter:
         :param float height: The height of the new page expressed in default
             user space units.
         :return: the newly appended page
-        :rtype: :class:`PageObject<PyPDF2._page.PageObject>`
         :raises PageSizeNotDefinedError: if width and height are not defined
             and previous page does not exist.
         """
@@ -316,7 +314,6 @@ class PdfWriter:
             user space units.
         :param int index: Position to add the page.
         :return: the newly appended page
-        :rtype: :class:`PageObject<PyPDF2._page.PageObject>`
         :raises PageSizeNotDefinedError: if width and height are not defined
             and previous page does not exist.
         """

--- a/PyPDF2/constants.py
+++ b/PyPDF2/constants.py
@@ -10,7 +10,7 @@ PDF Reference, sixth edition, Version 1.7, 2006.
 
 
 class Core:
-    """Keywords that don't quite belong anywhere else"""
+    """Keywords that don't quite belong anywhere else."""
 
     OUTLINES = "/Outlines"
     PAGE = "/Page"
@@ -33,7 +33,7 @@ class CatalogAttributes:
 
 class EncryptionDictAttributes:
     """
-    Additional encryption dictionary entries for the standard security handler
+    Additional encryption dictionary entries for the standard security handler.
 
     TABLE 3.19, Page 122
     """
@@ -46,7 +46,7 @@ class EncryptionDictAttributes:
 
 
 class Ressources:
-    """TABLE 3.30 Entries in a resource dictionary"""
+    """TABLE 3.30 Entries in a resource dictionary."""
 
     EXT_G_STATE = "/ExtGState"  # dictionary, optional
     COLOR_SPACE = "/ColorSpace"  # dictionary, optional
@@ -59,7 +59,7 @@ class Ressources:
 
 
 class PagesAttributes:
-    """Page Attributes, Table 6.2, Page 52"""
+    """Page Attributes, Table 6.2, Page 52."""
 
     TYPE = "/Type"  # name, required; must be /Pages
     KIDS = "/Kids"  # array, required; List of indirect references
@@ -68,7 +68,7 @@ class PagesAttributes:
 
 
 class PageAttributes:
-    """TABLE 3.27 Entries in a page object"""
+    """TABLE 3.27 Entries in a page object."""
 
     TYPE = "/Type"  # name, required; must be /Page
     PARENT = "/Parent"  # dictionary, required; a pages object
@@ -104,7 +104,7 @@ class PageAttributes:
 
 
 class StreamAttributes:
-    """Table 4.2"""
+    """Table 4.2."""
 
     LENGTH = "/Length"  # integer, required
     FILTER = "/Filter"  # name or array of names, optional
@@ -113,7 +113,7 @@ class StreamAttributes:
 
 class FilterTypes:
     """
-    Table 4.3 of the 1.4 Manual
+    Table 4.3 of the 1.4 Manual.
 
     Page 354 of the 1.7 Manual
     """
@@ -128,7 +128,7 @@ class FilterTypes:
 
 
 class FilterTypeAbbreviations:
-    """Table 4.44 of the 1.7 Manual (page 353ff)"""
+    """Table 4.44 of the 1.7 Manual (page 353ff)."""
 
     AHx = "/AHx"
     A85 = "/A85"
@@ -140,7 +140,7 @@ class FilterTypeAbbreviations:
 
 
 class LzwFilterParameters:
-    """Table 4.4"""
+    """Table 4.4."""
 
     PREDICTOR = "/Predictor"  # integer
     COLUMNS = "/Columns"  # integer
@@ -150,7 +150,7 @@ class LzwFilterParameters:
 
 
 class CcittFaxDecodeParameters:
-    """Table 4.5"""
+    """Table 4.5."""
 
     K = "/K"  # integer
     END_OF_LINE = "/EndOfLine"  # boolean
@@ -184,7 +184,7 @@ class ColorSpaces:
 
 
 class TypArguments:
-    """Table 8.2 of the PDF 1.7 reference"""
+    """Table 8.2 of the PDF 1.7 reference."""
 
     LEFT = "/Left"
     RIGHT = "/Right"
@@ -193,7 +193,7 @@ class TypArguments:
 
 
 class TypFitArguments:
-    """Table 8.2 of the PDF 1.7 reference"""
+    """Table 8.2 of the PDF 1.7 reference."""
 
     FIT = "/Fit"
     FIT_V = "/FitV"
@@ -205,7 +205,7 @@ class TypFitArguments:
 
 
 class FieldDistionaryAttributes:
-    """TABLE 8.69 Entries common to all field dictionaries (PDF 1.7 reference)"""
+    """TABLE 8.69 Entries common to all field dictionaries (PDF 1.7 reference)."""
 
     FT = "/FT"  # name, required for terminal fields
     Parent = "/Parent"  # dictionary, required for children
@@ -220,7 +220,7 @@ class FieldDistionaryAttributes:
 
 
 class DocumentInformationAttributes:
-    """TABLE 10.2 Entries in the document information dictionary"""
+    """TABLE 10.2 Entries in the document information dictionary."""
 
     TITLE = "/Title"  # text string, optional
     AUTHOR = "/Author"  # text string, optional
@@ -234,7 +234,7 @@ class DocumentInformationAttributes:
 
 
 class PageLayouts:
-    """Page 84, PDF 1.4 reference"""
+    """Page 84, PDF 1.4 reference."""
 
     SINGLE_PAGE = "/SinglePage"
     ONE_COLUMN = "/OneColumn"
@@ -243,7 +243,7 @@ class PageLayouts:
 
 
 class GraphicsStateParameters:
-    """Table 4.8 of the 1.7 reference"""
+    """Table 4.8 of the 1.7 reference."""
 
     TYPE = "/Type"  # name, optional
     LW = "/LW"  # number, optional
@@ -253,7 +253,7 @@ class GraphicsStateParameters:
 
 
 class CatalogDictionary:
-    """Table 3.25 in the 1.7 reference"""
+    """Table 3.25 in the 1.7 reference."""
 
     TYPE = "/Type"  # name, required; must be /Catalog
     VERSION = "/Version"  # name

--- a/PyPDF2/errors.py
+++ b/PyPDF2/errors.py
@@ -1,3 +1,10 @@
+"""
+All errors/exceptions PyPDF2 raises and all of the warnings it uses.
+
+Please note that broken PDF files might cause other Exceptions.
+"""
+
+
 class DependencyError(Exception):
     pass
 

--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -85,6 +85,8 @@ class FlateDecode:
         **kwargs: Any,
     ) -> bytes:
         """
+        Decode data which is flate-encoded.
+
         :param data: flate-encoded data.
         :param decode_parms: a dictionary of values, understanding the
             "/Predictor":<int> key only
@@ -378,7 +380,7 @@ class JPXDecode:
 
 
 class CCITParameters:
-    """TABLE 3.9 Optional parameters for the CCITTFaxDecode filter"""
+    """TABLE 3.9 Optional parameters for the CCITTFaxDecode filter."""
 
     def __init__(self, K: int = 0, columns: int = 0, rows: int = 0) -> None:
         self.K = K

--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -266,8 +266,6 @@ class LZWDecode:
             algorithm derived from:
             http://www.rasip.fer.hr/research/compress/algorithms/fund/lz/lzw.html
             and the PDFReference
-
-            :rtype: bytes
             """
             cW = self.CLEARDICT
             baos = ""
@@ -310,7 +308,6 @@ class LZWDecode:
         :param data: ``bytes`` or ``str`` text to decode.
         :param decode_parms: a dictionary of parameter values.
         :return: decoded data.
-        :rtype: bytes
         """
         if "decodeParms" in kwargs:  # pragma: no cover
             deprecate_with_replacement("decodeParms", "parameters", "4.0.0")

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1807,74 +1807,42 @@ class Destination(TreeObject):
 
     @property
     def title(self) -> Optional[str]:
-        """
-        Read-only property accessing the destination title.
-
-        :rtype: str
-        """
+        """Read-only property accessing the destination title."""
         return self.get("/Title")
 
     @property
     def page(self) -> Optional[int]:
-        """
-        Read-only property accessing the destination page number.
-
-        :rtype: int
-        """
+        """Read-only property accessing the destination page number."""
         return self.get("/Page")
 
     @property
     def typ(self) -> Optional[str]:
-        """
-        Read-only property accessing the destination type.
-
-        :rtype: str
-        """
+        """Read-only property accessing the destination type."""
         return self.get("/Type")
 
     @property
     def zoom(self) -> Optional[int]:
-        """
-        Read-only property accessing the zoom factor.
-
-        :rtype: int, or ``None`` if not available.
-        """
+        """Read-only property accessing the zoom factor."""
         return self.get("/Zoom", None)
 
     @property
     def left(self) -> Optional[FloatObject]:
-        """
-        Read-only property accessing the left horizontal coordinate.
-
-        :rtype: float, or ``None`` if not available.
-        """
+        """Read-only property accessing the left horizontal coordinate."""
         return self.get("/Left", None)
 
     @property
     def right(self) -> Optional[FloatObject]:
-        """
-        Read-only property accessing the right horizontal coordinate.
-
-        :rtype: float, or ``None`` if not available.
-        """
+        """Read-only property accessing the right horizontal coordinate."""
         return self.get("/Right", None)
 
     @property
     def top(self) -> Optional[FloatObject]:
-        """
-        Read-only property accessing the top vertical coordinate.
-
-        :rtype: float, or ``None`` if not available.
-        """
+        """Read-only property accessing the top vertical coordinate."""
         return self.get("/Top", None)
 
     @property
     def bottom(self) -> Optional[FloatObject]:
-        """
-        Read-only property accessing the bottom vertical coordinate.
-
-        :rtype: float, or ``None`` if not available.
-        """
+        """Read-only property accessing the bottom vertical coordinate."""
         return self.get("/Bottom", None)
 
 

--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -26,9 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-"""
-Implementation of generic PDF objects (dictionary, number, string, and so on).
-"""
+"""Implementation of generic PDF objects (dictionary, number, string, ...)."""
 __author__ = "Mathieu Fenniak"
 __author_email__ = "biziqe@mathieu.fenniak.net"
 
@@ -1558,7 +1556,9 @@ class RectangleObject(ArrayObject):
 
 class Field(TreeObject):
     """
-    A class representing a field dictionary. This class is accessed through
+    A class representing a field dictionary.
+
+    This class is accessed through
     :meth:`get_fields()<PyPDF2.PdfReader.get_fields>`
     """
 
@@ -1915,8 +1915,7 @@ def create_string_object(
     forced_encoding: Union[None, str, List[str], Dict[int, str]] = None,
 ) -> Union[TextStringObject, ByteStringObject]:
     """
-    Given a string, create a ByteStringObject or a TextStringObject to
-    represent the string.
+    Create a ByteStringObject or a TextStringObject from a string to represent the string.
 
     :param string: A string
 

--- a/PyPDF2/pagerange.py
+++ b/PyPDF2/pagerange.py
@@ -107,6 +107,7 @@ class PageRange:
     def indices(self, n: int) -> Tuple[int, int, int]:
         """
         n is the length of the list of pages to choose from.
+
         Returns arguments for range().  See help(slice.indices).
         """
         return self._slice.indices(n)
@@ -141,8 +142,8 @@ def parse_filename_page_ranges(
     args: List[Union[str, PageRange, None]]
 ) -> List[Tuple[str, PageRange]]:
     """
-    Given a list of filenames and page ranges, return a list of
-    (filename, page_range) pairs.
+    Given a list of filenames and page ranges, return a list of (filename, page_range) pairs.
+
     First arg must be a filename; other ags are filenames, page-range
     expressions, slice objects, or PageRange objects.
     A filename not followed by a page range indicates all pages of the file.

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -1,3 +1,9 @@
+"""
+Anything related to XMP metadata.
+
+See https://en.wikipedia.org/wiki/Extensible_Metadata_Platform
+"""
+
 import datetime
 import decimal
 import re
@@ -479,7 +485,7 @@ class XmpInformation(PdfObject):
     @property
     def custom_properties(self) -> Dict[Any, Any]:
         """
-        Retrieves custom metadata properties defined in the undocumented pdfx
+        Retrieve custom metadata properties defined in the undocumented pdfx
         metadata schema.
 
         :return: a dictionary of key/value items for custom metadata properties.

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -421,9 +421,9 @@ class XmpInformation(PdfObject):
         _getter_single(XMP_NAMESPACE, "MetadataDate", _converter_date)
     )
     """
-    The date and time that any metadata for this resource was last
-    changed.  The date and time are returned as a UTC datetime.datetime
-    object.
+    The date and time that any metadata for this resource was last changed.
+
+    The date and time are returned as a UTC datetime.datetime object.
     """
 
     @property
@@ -437,9 +437,7 @@ class XmpInformation(PdfObject):
         self.xmp_metadata_date = value
 
     xmp_creator_tool = property(_getter_single(XMP_NAMESPACE, "CreatorTool"))
-    """
-    The name of the first known tool used to create the resource.
-    """
+    """The name of the first known tool used to create the resource."""
 
     @property
     def xmp_creatorTool(self) -> str:  # pragma: no cover

--- a/PyPDF2/xmp.py
+++ b/PyPDF2/xmp.py
@@ -489,7 +489,6 @@ class XmpInformation(PdfObject):
         metadata schema.
 
         :return: a dictionary of key/value items for custom metadata properties.
-        :rtype: dict
         """
         if not hasattr(self, "_custom_properties"):
             self._custom_properties = {}


### PR DESCRIPTION
* `rtype` was removed in most cases. It makes sense sometimes, but only if it is not exactly what the type annotation is
* No newlines after the function docstring
* Keep lines under 80 characters. It's mostly not an issue for docstrings.

See PEP-257 for some guides.

flake8-naming was used to find those spots.