### PR TITLE
DOC: remove hyphen from lossless

### DIFF
--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -48,10 +48,10 @@ with open("out.pdf", "wb") as f:
     writer.write(f)
 ```
 
-## Loss-less Compression
+## Lossless Compression
 
 PyPDF2 supports the FlateDecode filter which uses the zlib/deflate compression
-method. It is a loss-less compression, meaning the resulting PDF looks exactly
+method. It is a lossless compression, meaning the resulting PDF looks exactly
 the same.
 
 Deflate compression can be applied to a page via [`page.compress_content_streams`](https://pypdf2.readthedocs.io/en/latest/modules/PageObject.html#PyPDF2._page.PageObject.compress_content_streams):


### PR DESCRIPTION
After years doing stuff with FLAC files and only ever see it referred to as "lossless", seeing the hyphen in "loss-less" bothers me. As a secondary reference, wikipedia's article on the subject is titled [lossless compression](https://en.wikipedia.org/wiki/Lossless_compression).