### PR TITLE
TST: Simplify pathlib PdfReader test

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -691,7 +691,7 @@ def test_extract_text_hello_world():
 
 
 def test_read_path():
-    path = Path(os.path.join(RESOURCE_ROOT, "crazyones.pdf"))
+    path = Path(RESOURCE_ROOT, "crazyones.pdf")
     reader = PdfReader(path)
     assert len(reader.pages) == 1
 


### PR DESCRIPTION
The `Path` constructor allows a variable amount of arguments to it which it joins together similar to `os.path.join` works, so it's not necessary to use `os.path.join` before passing the args to `Path`.

REPL example:
```
>>> os.path.join(RESOURCES_PATH, 'crazyones.pdf')
'/Users/mpeveler/code/github/PyPDF2/resources/crazyones.pdf'
>>> Path(os.path.join(RESOURCES_PATH, 'crazyones.pdf'))
PosixPath('/Users/mpeveler/code/github/PyPDF2/resources/crazyones.pdf')
>>> Path(RESOURCES_PATH, 'crazyones.pdf')
PosixPath('/Users/mpeveler/code/github/PyPDF2/resources/crazyones.pdf')
```