### PR TITLE
_cmap.py: avoid IndexError in parse_to_unicode

### DIFF
--- a/PyPDF2/_cmap.py
+++ b/PyPDF2/_cmap.py
@@ -245,7 +245,7 @@ def parse_to_unicode(
         elif process_char:
             lst = [x for x in l.split(b" ") if x]
             map_dict[-1] = len(lst[0]) // 2
-            while len(lst) > 0:
+            while len(lst) > 1:
                 map_dict[
                     unhexlify(lst[0]).decode(
                         "charmap" if map_dict[-1] == 1 else "utf-16-be", "surrogatepass"


### PR DESCRIPTION
The code within the if block assumes that lst has index 0 and index 1.
So the predicate should depend on lst having at least two elements.

This resolves the error I described at
https://github.com/py-pdf/PyPDF2/issues/1091#issuecomment-1184718747
(I'm not sure that it would resolve the other issue raised by
@MartinThoma)