### PR TITLE
Avoid a crash when a ToUnicode CMap has an empty dstString in beginbfchar

### DIFF
--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -1377,6 +1377,7 @@ class PageObject(DictionaryObject):
                         if (
                             (abs(float(op)) >= _space_width)
                             and (abs(float(op)) <= 8 * _space_width)
+                            and (len(text) > 0)
                             and (text[-1] != " ")
                         ):
                             process_operation(b"Tj", [" "])


### PR DESCRIPTION
This is not a principled fix, but it is a hack to avoid a crash when
encountering an empty dstString in a `beginbfchar` table in a
ToUnicode CMap.

The right way to fix this would be to replace all the string
manipulation with a formal grammar, but i don't have the skill or
capacity to do that right now.

Instead, we take narrow aim at the issue of zero-length (empty) hex
string representations.

We take advantage of the fact that no angle-bracket-delimited hex
string contains a . character.  when we encounter an empty hex string,
rather than replacing it with the empty string, we replace it with a
literal ".".  Then, when we encounter a ".", we remember that it was
supposed to be an empty string.

One consequence of this fix is that the exported cmap can now return
an empty string, so we also have to clean up
`PageObject::process_operation` so that it doesn't try to read the
final character from an empty string.

This is a hackish workaround for #1111.