### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/meta/project-governance.md
+++ b/docs/meta/project-governance.md
@@ -71,7 +71,7 @@ as their mother tongue. We try our best to understand others -
 The community can expect the following:
 
 * The **benevolent dictator** tries their best to make decisions from which the overall
-  community profits. The benevolent dictator is aware that his/her decisons can shape the
+  community profits. The benevolent dictator is aware that his/her decisions can shape the
   overall community. Once the benevolent dictator notices that she/he doesn't have the time
   to advance PyPDF2, he/she looks for a new benevolent dictator. As it is expected
   that the benevolent dictator will step down at some point of their choice

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -238,7 +238,7 @@ def test_get_images_raw(strict, with_prev_0, startx_correction, should_fail):
         pdf_data.find(b"4 0 obj"),
         pdf_data.find(b"5 0 obj"),
         b"/Prev 0 " if with_prev_0 else b"",
-        # startx_correction should be -1 due to double % at the beginning indiducing an error on startxref computation
+        # startx_correction should be -1 due to double % at the beginning inducing an error on startxref computation
         pdf_data.find(b"xref") + startx_correction,
     )
     pdf_stream = io.BytesIO(pdf_data)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -203,7 +203,7 @@ def test_remove_text_all_operators(ignore_byte_string_object):
         pdf_data.find(b"4 0 obj") + startx_correction,
         pdf_data.find(b"5 0 obj") + startx_correction,
         pdf_data.find(b"6 0 obj") + startx_correction,
-        # startx_correction should be -1 due to double % at the beginning indiducing an error on startxref computation
+        # startx_correction should be -1 due to double % at the beginning inducing an error on startxref computation
         pdf_data.find(b"xref"),
     )
     print(pdf_data.decode())


### PR DESCRIPTION
There are small typos in:
- docs/meta/project-governance.md
- tests/test_reader.py
- tests/test_writer.py

Fixes:
- Should read `inducing` rather than `indiducing`.
- Should read `decisions` rather than `decisons`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md