### PR TITLE
BUG: Add missing deprecated EncodedStreamObject functions

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1162,8 +1162,16 @@ class EncodedStreamObject(StreamObject):
             self.decoded_self = decoded
             return decoded._data
 
+    def getData(self) -> Union[None, str, bytes]:  # pragma: no cover
+        deprecate_with_replacement("getData", "get_data")
+        return self.get_data()
+
     def set_data(self, data: Any) -> None:
         raise PdfReadError("Creating EncodedStreamObject is not currently supported")
+
+    def setData(self, data: Any) -> None:  # pragma: no cover
+        deprecate_with_replacement("setData", "set_data")
+        return self.set_data(data)
 
 
 class ContentStream(DecodedStreamObject):


### PR DESCRIPTION
Closes #1138 

The `EncodedStreamObject` class was missing the deprecated `getData` and `setData` functions, which would call the `get_data` and `set_data` functions respectively after issuing a deprecation warning. The original functions were totally renamed in https://github.com/py-pdf/PyPDF2/commit/c774ab0cbc82c99a7dcbaa3260b6c4545f1b3659. That same commit did properly handle the `getData` and `setData` functions in the `DecodedStreamObject` though, where they issue a deprecation warning and then call `get_data` and `set_data`.

This should probably be backported to 1.x where it exists as well, as it should be simple enough, and the user in #1138 is using 1.28.2 and cannot upgrade due to this bug.