### PR TITLE
BUG: Add missing deprecated EncodedStreamObject functions

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -1163,8 +1163,24 @@ class EncodedStreamObject(StreamObject):
             self.decoded_self = decoded
             return decoded._data
 
+    def getData(self):
+        warnings.warn(
+            DEPR_MSG.format("getData", "get_data"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_data()
+
     def set_data(self, data):
         raise PdfReadError("Creating EncodedStreamObject is not currently supported")
+
+    def setData(self, data):
+        warnings.warn(
+            DEPR_MSG.format("setData", "set_data"),
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.set_data(data)
 
 
 class ContentStream(DecodedStreamObject):


### PR DESCRIPTION
Backport of #1139 applied against 1.x. Please see that PR for any discussion / review.

Once merged and a new 1.x release, will fix the issue for #1138 preventing upgrading to latest 1.x release.