### PR TITLE
BUG: Ignore if '/Perms' verify failed

### DIFF
--- a/PyPDF2/_encryption.py
+++ b/PyPDF2/_encryption.py
@@ -33,6 +33,7 @@ from typing import Optional, Tuple, Union, cast
 import warnings
 
 from PyPDF2.errors import DependencyError, PdfReadWarning
+from PyPDF2._utils import logger_warning
 from PyPDF2.generic import (
     ArrayObject,
     ByteStringObject,
@@ -827,7 +828,7 @@ class Encryption:
         P = (P + 0x100000000) % 0x100000000  # maybe < 0
         metadata_encrypted = self.entry.get("/EncryptMetadata", True)
         if not AlgV5.verify_perms(key, perms, P, metadata_encrypted):
-            warnings.warn("ignore '/Perms' verify failed", PdfReadWarning)
+            logger_warning("ignore '/Perms' verify failed", __name__)
         return key, rc
 
     @staticmethod

--- a/PyPDF2/_encryption.py
+++ b/PyPDF2/_encryption.py
@@ -30,8 +30,9 @@ import random
 import struct
 from enum import IntEnum
 from typing import Optional, Tuple, Union, cast
+import warnings
 
-from PyPDF2.errors import DependencyError
+from PyPDF2.errors import DependencyError, PdfReadWarning
 from PyPDF2.generic import (
     ArrayObject,
     ByteStringObject,
@@ -826,7 +827,7 @@ class Encryption:
         P = (P + 0x100000000) % 0x100000000  # maybe < 0
         metadata_encrypted = self.entry.get("/EncryptMetadata", True)
         if not AlgV5.verify_perms(key, perms, P, metadata_encrypted):
-            return b"", PasswordType.NOT_DECRYPTED
+            warnings.warn("ignore '/Perms' verify failed", PdfReadWarning)
         return key, rc
 
     @staticmethod

--- a/PyPDF2/_encryption.py
+++ b/PyPDF2/_encryption.py
@@ -30,9 +30,8 @@ import random
 import struct
 from enum import IntEnum
 from typing import Optional, Tuple, Union, cast
-import warnings
 
-from PyPDF2.errors import DependencyError, PdfReadWarning
+from PyPDF2.errors import DependencyError
 from PyPDF2._utils import logger_warning
 from PyPDF2.generic import (
     ArrayObject,


### PR DESCRIPTION
It seems to be save to ignore the /Perms entry:

Qpdf ignores it:
https://github.com/qpdf/qpdf/blob/main/libqpdf/QPDF_encryption.cc#L1064

pdfbox ignores it:
https://github.com/apache/pdfbox/blob/dc1a75027d5bebf95a3330f6298a533e78e0b99e/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/encryption/StandardSecurityHandler.java#L311

Closes #378 