### PR TITLE
ROB: Cope with empty DecodeParams

### DIFF
--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -104,7 +104,7 @@ class FlateDecode:
                             predictor = decode_parm["/Predictor"]
                 else:
                     predictor = decode_parms.get("/Predictor", 1)
-            except AttributeError:
+            except (AttributeError, TypeError):  # Type Error is NullObject
                 pass  # Usually an array with a null object was read
         # predictor 1 == no predictor
         if predictor != 1:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -151,6 +151,12 @@ def test_rotate_45():
         (True, "https://arxiv.org/pdf/2201.00029.pdf", [0, 1, 6, 10]),
         # #1145
         (True, "https://github.com/py-pdf/PyPDF2/files/9174594/2017.pdf", [0]),
+        # #1145, remaining issue (empty arguments for FlateEncoding)
+        (
+            True,
+            "https://github.com/py-pdf/PyPDF2/files/9175966/2015._pb_decode_pg0.pdf",
+            [0],
+        ),
         # 6 instead of 5: as there is an issue in page 5 (missing objects)
         # and too complex to handle the warning without hiding real regressions
         (True, "https://arxiv.org/pdf/1601.03642.pdf", [0, 1, 5, 7]),


### PR DESCRIPTION
See https://github.com/py-pdf/PyPDF2/issues/1143#issuecomment-1193329917 , 2nd part