### PR TITLE
BUG : Named Dest in PDF1.1(#1173)

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -644,9 +644,8 @@ class PdfReader:
             # recurse down the tree
             for kid in cast(ArrayObject, tree[PA.KIDS]):
                 self._get_named_destinations(kid.get_object(), retval)
-
         # TABLE 3.33 Entries in a name tree node dictionary (PDF 1.7 specs)
-        if CA.NAMES in tree:
+        elif CA.NAMES in tree:  # KIDS and NAMES are exclusives (PDF 1.7 specs p 162)
             names = cast(DictionaryObject, tree[CA.NAMES])
             for i in range(0, len(names), 2):
                 key = cast(str, names[i].get_object())
@@ -656,7 +655,12 @@ class PdfReader:
                 dest = self._build_destination(key, value)  # type: ignore
                 if dest is not None:
                     retval[key] = dest
-
+        else:  # case where Dests is in root catalog (PDF 1.7 specs, §2 about PDF1.1
+            for k__, v__ in tree.items():
+                val = v__.get_object()
+                dest = self._build_destination(k__, val)
+                if dest is not None:
+                    retval[k__] = dest
         return retval
 
     def getNamedDestinations(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -977,6 +977,21 @@ def test_outline_missing_title():
     assert exc.value.args[0].startswith("Outline Entry Missing /Title attribute:")
 
 
+def test_named_destination():
+    # 1st case : the named_dest are stored directly as a dictionnary, PDF1.1 style
+    url = "https://github.com/py-pdf/PyPDF2/files/9197028/lorem_ipsum.pdf"
+    name = "lorem_ipsum.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    assert len(reader.named_destinations) > 0
+    # 2nd case : Dest below names and with Kids...
+    url = "https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf"
+    name = "PDF32000_2008.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    assert len(reader.named_destinations) > 0
+    # 3nd case : Dests with Name tree
+    # TODO : case to be added
+
+
 def test_outline_with_missing_named_destination():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/913/913678.pdf"
     name = "tika-913678.pdf"


### PR DESCRIPTION
 Named dest are stored in a dictionnary in PDF 1.1
TODO : a test for named destination stored in name tree should be added to improve coverage
[#1173)