### PR TITLE
Fix changelog link in package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ url = https://pypdf2.readthedocs.io/en/latest/
 project_urls =
     Source = https://github.com/py-pdf/PyPDF2
     Bug Reports = https://github.com/py-pdf/PyPDF2/issues
-    Changelog = https://raw.githubusercontent.com/py-pdf/PyPDF2/main/CHANGELOG
+    Changelog = https://raw.githubusercontent.com/py-pdf/PyPDF2/main/CHANGELOG.md
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ url = https://pypdf2.readthedocs.io/en/latest/
 project_urls =
     Source = https://github.com/py-pdf/PyPDF2
     Bug Reports = https://github.com/py-pdf/PyPDF2/issues
-    Changelog = https://raw.githubusercontent.com/py-pdf/PyPDF2/main/CHANGELOG.md
+    Changelog = https://pypdf2.readthedocs.io/en/latest/meta/CHANGELOG.html
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Changelog file was updated from `CHANGELOG` to `CHANGELOG.md` in https://github.com/py-pdf/PyPDF2/pull/1023, but the link in package metadata has not been not updated.