### PR TITLE
BUG: Allow IndirectObjects as stream filters

### DIFF
--- a/PyPDF2/filters.py
+++ b/PyPDF2/filters.py
@@ -38,9 +38,9 @@ import math
 import struct
 import zlib
 from io import BytesIO
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
-from .generic import ArrayObject, DictionaryObject, NameObject
+from .generic import ArrayObject, DictionaryObject, IndirectObject, NameObject
 
 try:
     from typing import Literal  # type: ignore[attr-defined]
@@ -506,7 +506,8 @@ class CCITTFaxDecode:
 
 def decode_stream_data(stream: Any) -> Union[str, bytes]:  # utils.StreamObject
     filters = stream.get(SA.FILTER, ())
-
+    if isinstance(filters, IndirectObject):
+        filters = cast(ArrayObject, filters.get_object())
     if len(filters) and not isinstance(filters[0], NameObject):
         # we have a single filter instance
         filters = (filters,)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -219,3 +219,10 @@ def test_lzw_decode_neg1():
         for page in reader.pages:
             page.extract_text()
     assert exc.value.args[0] == "Missed the stop code in LZWDecode!"
+
+
+def test_issue_399():
+    url = "https://corpora.tika.apache.org/base/docs/govdocs1/976/976970.pdf"
+    name = "tika-976970.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    reader.pages[1].extract_text()


### PR DESCRIPTION
According to 'TABLE 3.4 Entries common to all stream dictionaries', no IndirectObject is expected there.

But also:

> Any object in a PDF file may be labeled as an indirect object.

Closes #399