### PR TITLE
Modify CI to better verify built package contents

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -89,10 +89,10 @@ jobs:
       - name: Check long_description
         run: python -m twine check dist/*
         
-      - name: Test installing wheel
-        run: python -m pip install dist/*.whl
-        
-      - name: Test running wheel
+      - name: Test installing package
+        run: python -m pip install .
+
+      - name: Test running installed package
         working-directory: /tmp
         run: python -c "import PyPDF2;print(PyPDF2.__version__)"
 

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -88,6 +88,13 @@ jobs:
       - run: check-wheel-contents dist/*.whl
       - name: Check long_description
         run: python -m twine check dist/*
+        
+      - name: Test installing wheel
+        run: python -m pip install dist/*.whl
+        
+      - name: Test running wheel
+        working-directory: /tmp
+        run: python -c "import PyPDF2;print(PyPDF2.__version__)"
 
       # - name: Release to pypi if tagged.
       #   if: startsWith(github.ref, 'refs/tags')

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,6 @@ crypto = PyCryptodome
 backup = False
 runner = ./mutmut-test.sh
 tests_dir = tests/
+
+[tool:check-wheel-contents]
+package = ./PyPDF2


### PR DESCRIPTION
PR modifies the package CI job in two ways:
1. Pass `package` to `check-wheel-contents` (see [action failure example](https://github.com/MasterOdin/PyPDF2/runs/7841851535?check_suite_focus=true)). This makes it so that `check-wheel-contents` verifies that each file in the package are actually in the wheel following their directory structure.
2. Have CI steps that verify we can install the package, and that we can run a minimal example with it (see [action failure example](https://github.com/MasterOdin/PyPDF2/runs/7841756654?check_suite_focus=true))

Either of these steps would have been sufficient to have caught #1242 per the example runs above.