### PR TITLE
Add min version for typing_extensions requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages =
     PyPDF2.generic
 python_requires = >=3.6
 install_requires =
-    typing_extensions; python_version < '3.10'
+    typing_extensions >= 3.10.0.0; python_version < '3.10'
 
 [options.extras_require]
 crypto = PyCryptodome


### PR DESCRIPTION
I stumbled upon this while having an older typing_extensions version
installed. According to my investigation TypeAlias was introduced with
typing_extensions 3.10.0 which makes sense since it is a Python 3.10
feature.