### PR TITLE
ROB: Add required line separators in ContentStream ArrayObjects

### DIFF
--- a/PyPDF2/generic/_data_structures.py
+++ b/PyPDF2/generic/_data_structures.py
@@ -679,6 +679,8 @@ class ContentStream(DecodedStreamObject):
             data = b""
             for s in stream:
                 data += b_(s.get_object().get_data())
+                if data[-1] != b"\n":
+                    data += b"\n"
             stream_bytes = BytesIO(data)
         else:
             stream_data = stream.get_data()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -265,6 +265,11 @@ def test_iss_1142():
             "https://github.com/py-pdf/PyPDF2/files/9150656/ST.2019.PDF",
             "iss_1134.pdf",
         ),
+        # iss 1:
+        (
+            "https://github.com/py-pdf/PyPDF2/files/9432350/Work.Flow.From.Check.to.QA.pdf",
+            "WFCA.pdf",
+        ),
     ],
 )
 def test_extract_text_page_pdf(url, name):


### PR DESCRIPTION
fix #1278