### PR TITLE
Found & Fixed None type values for TK.INFO keys in self.trailer (_reader.py)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ history and [GitHubs 'Contributors' feature](https://github.com/py-pdf/PyPDF2/gr
 
 ## Contributors to the pyPdf / PyPDF2 project
 
+* [ediamondscience](https://github,com.ediamondscience)
 * [JianzhengLuo](https://github.com/JianzhengLuo)
 * [Karvonen, Harry](https://github.com/Hatell/)
 * [KourFrost](https://github.com/KourFrost)

--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -322,10 +322,13 @@ class PdfReader:
 
         :return: the document information of this PDF file
         """
-        if TK.INFO not in self.trailer:
+        if self.trailer[TK.INFO]==None:
             return None
         obj = self.trailer[TK.INFO]
+        print(obj)
         retval = DocumentInformation()
+        if retval==None:
+            retval={}
         retval.update(obj)  # type: ignore
         return retval
 


### PR DESCRIPTION
Fixed Dictionary self.trailer storing None values self.trailer was storing a vlaue for [TK.INFO] inputs where TK.INFO was expected in _reader.py.
In relation to issue https://github.com/py-pdf/PyPDF2/issues/1279 , when we call print(obj) in _reader.py we get None in the console. TK.INFO was a key in the python dictionary that makes up self.trailer, but had it's value stored as None.  
```
        if TK.INFO not in self.trailer:
            return None
        obj = self.trailer[TK.INFO]
```
When we tried calling
```
        retval.update(obj)  # type: ignore
```
We were trying to update an empty dictionary with a NoneType, hence the error message. 

I've replaced the first line of code in this pull request with 
```
        if self.trailer[TK.INFO]==None:
            return None
```

This should return None if nothing is assigned to retval and there is no additional metadata to read with this function.

Please let me know what you think of these revisions. I'd be happy to alter them if the project feels that we should raise an error instead of just returning a value of None. 