### PR TITLE
MAINT: Remove catching OverflowException

### DIFF
--- a/PyPDF2/generic/_base.py
+++ b/PyPDF2/generic/_base.py
@@ -272,10 +272,7 @@ class NumberObject(int, PdfObject):
 
     def __new__(cls, value: Any) -> "NumberObject":
         val = int(value)
-        try:
-            return int.__new__(cls, val)
-        except OverflowError:
-            return int.__new__(cls, 0)
+        return int.__new__(cls, val)
 
     def as_numeric(self) -> int:
         return int(repr(self).encode("utf8"))

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -43,9 +43,8 @@ def test_float_object_exception():
     assert FloatObject("abc") == 0
 
 
-def test_number_object_exception():
-    with pytest.raises(OverflowError):
-        NumberObject(1.5 * 2**10000)
+def test_number_object_no_exception():
+    NumberObject(2**100000000)
 
 
 def test_create_string_object_exception():


### PR DESCRIPTION
Since Python 2.2 (PEP 237), integers cannot throw overflow exceptions.