### PR TITLE
BUG: Avoid scaling cropbox twice

### DIFF
--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -952,11 +952,11 @@ class PageObject(DictionaryObject):
         :param float sy: The scaling factor on vertical axis.
         """
         self.add_transformation((sx, 0, 0, sy, 0, 0))
-        self.mediabox = self.mediabox.scale(sx, sy)
         self.cropbox = self.cropbox.scale(sx, sy)
         self.artbox = self.artbox.scale(sx, sy)
         self.bleedbox = self.bleedbox.scale(sx, sy)
         self.trimbox = self.trimbox.scale(sx, sy)
+        self.mediabox = self.mediabox.scale(sx, sy)
         if PG.VP in self:
             viewport = self[PG.VP]
             if isinstance(viewport, ArrayObject):


### PR DESCRIPTION
When pdf has no crobox, artbox, etc, they are fallback to mediabox. As they are lazy, `self.cropbox` returns the `mediabox` copy which already was scaled.