### PR TITLE
fix if u_value contains redundant data

### DIFF
--- a/PyPDF2/_encryption.py
+++ b/PyPDF2/_encryption.py
@@ -516,10 +516,10 @@ class AlgV5:
            should match the value in the P key.
         """
         password = password[:127]
-        if AlgV5.calculate_hash(R, password, o_value[32:40], u_value) != o_value[:32]:
+        if AlgV5.calculate_hash(R, password, o_value[32:40], u_value[:48]) != o_value[:32]:
             return b""
         iv = bytes(0 for _ in range(16))
-        tmp_key = AlgV5.calculate_hash(R, password, o_value[40:], u_value)
+        tmp_key = AlgV5.calculate_hash(R, password, o_value[40:48], u_value[:48])
         key = AES_CBC_decrypt(tmp_key, iv, oe_value)
         return key
 
@@ -532,7 +532,7 @@ class AlgV5:
         if AlgV5.calculate_hash(R, password, u_value[32:40], b"") != u_value[:32]:
             return b""
         iv = bytes(0 for _ in range(16))
-        tmp_key = AlgV5.calculate_hash(R, password, u_value[40:], b"")
+        tmp_key = AlgV5.calculate_hash(R, password, u_value[40:48], b"")
         return AES_CBC_decrypt(tmp_key, iv, ue_value)
 
     @staticmethod


### PR DESCRIPTION
fix #1288 

the specification says:
> To understand the algorithm below, it is necessary to treat the O and U strings in the Encrypt dictionary
> as made up of three sections. The first 32 bytes are a hash value (explained below). The next 8 bytes are
> called the Validation Salt. The final 8 bytes are called the Key Salt.

so `/U` and `/O` should be 48-bytes data.
but for the pdf which causes #1288 , `/O` 's length is 127-bytes, the redundant data are zeros.