### PR TITLE
TST: Use pytest.warns() for warnings, and .raises() for exceptions

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,10 +107,10 @@ def test_b():
 
 
 def test_deprecate_no_replacement():
-    with pytest.raises(PendingDeprecationWarning) as exc:
+    with pytest.warns(PendingDeprecationWarning) as warn:
         PyPDF2._utils.deprecate_no_replacement("foo")
     error_msg = "foo is deprecated and will be removed in PyPDF2 3.0.0."
-    assert exc.value.args[0] == error_msg
+    assert warn[0].message.args[0] == error_msg
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -260,62 +260,26 @@ def test_extract_textbench(enable, url, pages, print_result=False):
 
 def test_orientations():
     p = PdfReader(RESOURCE_ROOT / "test Orient.pdf").pages[0]
-    try:
+    with pytest.warns(DeprecationWarning):
         p.extract_text("", "")
-    except DeprecationWarning:
-        pass
-    else:
-        raise Exception("DeprecationWarning expected")
-    try:
+    with pytest.warns(DeprecationWarning):
         p.extract_text("", "", 0)
-    except DeprecationWarning:
-        pass
-    else:
-        raise Exception("DeprecationWarning expected")
-    try:
+    with pytest.warns(DeprecationWarning):
         p.extract_text("", "", 0, 200)
-    except DeprecationWarning:
-        pass
-    else:
-        raise Exception("DeprecationWarning expected")
 
-    try:
+    with pytest.warns(DeprecationWarning):
         p.extract_text(Tj_sep="", TJ_sep="")
-    except DeprecationWarning:
-        pass
-    else:
-        raise Exception("DeprecationWarning expected")
     assert findall("\\((.)\\)", p.extract_text()) == ["T", "B", "L", "R"]
-    try:
+    with pytest.raises(Exception):
         p.extract_text(None)
-    except Exception:
-        pass
-    else:
-        raise Exception("Argument 1 check invalid")
-    try:
+    with pytest.raises(Exception):
         p.extract_text("", 0)
-    except Exception:
-        pass
-    else:
-        raise Exception("Argument 2 check invalid")
-    try:
+    with pytest.raises(Exception):
         p.extract_text("", "", None)
-    except Exception:
-        pass
-    else:
-        raise Exception("Argument 3 check invalid")
-    try:
+    with pytest.raises(Exception):
         p.extract_text("", "", 0, "")
-    except Exception:
-        pass
-    else:
-        raise Exception("Argument 4 check invalid")
-    try:
+    with pytest.raises(Exception):
         p.extract_text(0, "")
-    except Exception:
-        pass
-    else:
-        raise Exception("Argument 1 new syntax check invalid")
 
     p.extract_text(0, 0)
     p.extract_text(orientations=0)


### PR DESCRIPTION
Replace the warning-as-exception checks with use of `pytest.warns()`
that is more semantically correct and works correctly when the tests
are run without -Werror (e.g. because -Werror tends to cause test suites
to crash on irrelevant deprecation warnings from other components).
While at it, replace the homegrown exception checks in test_orientations
with `pytest.raises()`.