### PR TITLE
BUG: Adjust 'super' calls for Python 2

### DIFF
--- a/PyPDF2/_reader.py
+++ b/PyPDF2/_reader.py
@@ -1868,4 +1868,4 @@ class PdfFileReader(PdfReader):
         )
         if "strict" not in kwargs and len(args) < 2:
             kwargs["strict"] = True  # maintain the default
-        super().__init__(*args, **kwargs)
+        super(PdfFileReader, self).__init__(*args, **kwargs)

--- a/PyPDF2/_utils.py
+++ b/PyPDF2/_utils.py
@@ -206,7 +206,7 @@ class ConvertFunctionsToVirtualList(_VirtualList):
             stacklevel=2,
         )
         warnings.warn(DEPR_MSG_NO_REPLACEMENT.format("ConvertFunctionsToVirtualList"))
-        super().__init__(lengthFunction, getFunction)
+        super(ConvertFunctionsToVirtualList, self).__init__(lengthFunction, getFunction)
 
 
 def matrix_multiply(a, b):

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -1774,4 +1774,4 @@ class PdfFileWriter(PdfWriter):
             PendingDeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(*args, **kwargs)
+        super(PdfFileWriter, self).__init__(*args, **kwargs)

--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -766,4 +766,4 @@ class PdfFileMerger(PdfMerger):
         )
         if "strict" not in kwargs and len(args) < 1:
             kwargs["strict"] = True  # maintain the default
-        super().__init__(*args, **kwargs)
+        super(PdfFileMerger, self).__init__(*args, **kwargs)


### PR DESCRIPTION
In python 2 it is still necessary to pass the class and object of the super function. 
This is missing in a few places.

The error looks like this:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in __init__
TypeError: super() takes at least 1 argument (0 given)
```
Our customers still use python 2 so we need Pypdf2 in a python 2 compatible version. 
Unfortunatly, it is not possible to migrate to python 3 soon, thus it would be very to fix this. Thanks!