### PR TITLE
ROB: Cope with cmap from #1322

### DIFF
--- a/PyPDF2/_cmap.py
+++ b/PyPDF2/_cmap.py
@@ -1,5 +1,6 @@
 import warnings
 from binascii import unhexlify
+from math import ceil
 from typing import Any, Dict, List, Tuple, Union, cast
 
 from ._codecs import adobe_glyphs, charset_encoding
@@ -267,9 +268,9 @@ def parse_bfrange(
 ) -> Union[None, Tuple[int, int]]:
     lst = [x for x in l.split(b" ") if x]
     closure_found = False
-    nbi = len(lst[0])
-    map_dict[-1] = nbi // 2
-    fmt = b"%%0%dX" % nbi
+    nbi = max(len(lst[0]), len(lst[1]))
+    map_dict[-1] = ceil(nbi / 2)
+    fmt = b"%%0%dX" % (map_dict[-1] * 2)
     if multiline_rg is not None:
         a = multiline_rg[0]  # a, b not in the current line
         b = multiline_rg[1]


### PR DESCRIPTION
fixes #1370 
cope with cmap where the range contains first and last   code are on variable length.
Also fix cases where the code is on 3 characters only (not standard)
no test data available