### PR TITLE
BUG: td matrix

### DIFF
--- a/PyPDF2/_page.py
+++ b/PyPDF2/_page.py
@@ -1490,8 +1490,13 @@ class PageObject(DictionaryObject):
             # Table 5.5 page 406
             elif operator == b"Td":
                 check_crlf_space = True
-                tm_matrix[4] += float(operands[0])
-                tm_matrix[5] += float(operands[1])
+                # A special case is a translating only tm:
+                # tm[0..5] = 1 0 0 1 e f,
+                # i.e. tm[4] += tx, tm[5] += ty.
+                tx = float(operands[0])
+                ty = float(operands[1])
+                tm_matrix[4] += tx * tm_matrix[0] + ty * tm_matrix[2]
+                tm_matrix[5] += tx * tm_matrix[1] + ty * tm_matrix[3]
             elif operator == b"Tm":
                 check_crlf_space = True
                 tm_matrix = [

--- a/resources/Sample_Td-matrix.pdf
+++ b/resources/Sample_Td-matrix.pdf
@@ -1,0 +1,72 @@
+%PDF-1.4
+%----
+1 0 obj
+<< /Pages 3 0 R
+   /Type /Catalog /Version /1.4 >>
+endobj
+2 0 obj
+<< /CreationDate (D:20220823232400+02'00') /Producer (vim) >>
+endobj
+3 0 obj
+<< /Count 1 /Kids [ 4 0 R ] /Type /Pages >>
+endobj
+4 0 obj
+<< /Contents [ 5 0 R ] /MediaBox [ 0 0 842 595 ] /Parent 3 0 R
+   /Resources << /Font << /F1 6 0 R >> >> /TrimBox [ 0 0 842 595 ]
+   /Type /Page >>
+endobj
+5 0 obj
+<< /Length 0575 >>
+stream
+0.0 G
+0.0 0.0 1.0 rg 200 100 200 100 re B
+0.2 0.2 1.0 rg 400 100 200 100 re B
+0.4 0.4 1.0 rg 200 200 200 100 re B
+0.6 0.6 1.0 rg 400 200 200 100 re B
+
+0.3 0.0 0.0 rg
+BT
+   % Move text to 210 110 via Td-operation
+   /F1 12 Tf
+   210 110 Td
+   (Hello PDF\041) Tj
+
+   % Tm-operation without scale followed by Td
+   1 0 0 1 200 0 Tm
+   210 110 Td
+   (Hello PDF 200 0 Td!) Tj
+
+   % Tm-operation with horizontal scale
+   2 0 0 1 0 0 Tm
+   105 210 Td
+   (Hello PDF 2 1!) Tj
+
+   % Tm-operation with dual scale
+   /F1 2.5 Tf
+   10 0 0 7 0 0 Tm
+   41 30 Td
+   (Hello PDF 10 7!) Tj
+
+ET
+endstream
+endobj
+6 0 obj
+<< /Type /Font
+   /Subtype /Type1
+   /BaseFont /Helvetica-Bold
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000081 00000 n 
+0000000158 00000 n 
+0000000217 00000 n 
+0000000380 00000 n 
+0000001006 00000 n 
+trailer << /Size 7 /Info 2 0 R /Root 1 0 R >>
+startxref
+1087
+%%EOF
+

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -617,9 +617,11 @@ def test_extract_text_visitor_callbacks():
     page_td_model = reader.pages[0]
     # We store the translations of the Td-executions.
     list_Td = []
+
     def visitor_td(op, args, cm, tm):
         if op == b"Td":
             list_Td.append((tm[4], tm[5]))
+
     page_td_model.extract_text(visitor_operand_after=visitor_td)
     assert len(list_Td) == 4
     # Check the translations of the four Td-executions.

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -297,7 +297,14 @@ def test_iss_1142():
     name = "st2019.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     txt = reader.pages[3].extract_text()
-    assert txt.find("有限公司郑州分公司") > 0
+    # The following text is contained in two different cells:
+    # assert txt.find("有限公司郑州分公司") > 0
+    # 有限公司 = limited company
+    # 郑州分公司 = branch office in Zhengzhou
+    # First cell (see page 4/254):
+    assert txt.find("郑州药素电子商务有限公司") > 0
+    # Next cell (first cell in next line):
+    assert txt.find("郑州分公司") > 0
 
 
 @pytest.mark.parametrize(
@@ -603,6 +610,23 @@ def test_extract_text_visitor_callbacks():
     assert texts.get_base_font() == "/Arial"
     assert texts.font_dict["/Encoding"] == "/WinAnsiEncoding"
     assert text_dat_of_date.font_size == 9.96
+
+    # Test 3: Read a table in a document using a non-translating
+    #         but scaling Tm-operand
+    reader = PdfReader(RESOURCE_ROOT / "Sample_Td-matrix.pdf")
+    page_td_model = reader.pages[0]
+    # We store the translations of the Td-executions.
+    list_Td = []
+    def visitor_td(op, args, cm, tm):
+        if op == b"Td":
+            list_Td.append((tm[4], tm[5]))
+    page_td_model.extract_text(visitor_operand_after=visitor_td)
+    assert len(list_Td) == 4
+    # Check the translations of the four Td-executions.
+    assert list_Td[0] == (210.0, 110.0)
+    assert list_Td[1] == (410.0, 110.0)
+    assert list_Td[2] == (210.0, 210.0)
+    assert list_Td[3] == (410.0, 210.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR contains a bugfix which introduces a matrix multiplication [1 0 0 1 tx ty] * tm_matrix when processing operator Td (see 5.3.1 Text-Positioning Operators, p. 406). This is important in cases where the text matrix is not like [1 0 0 1 e f].

I added an ASCII-sample pdf file which contains such a text matrix:
```
   10 0 0 7 0 0 Tm
   41 30 Td
   (Hello PDF 10 7!) Tj
```
The test file ST.2019.pdf of #1142 contains such text matrices:
```
9 -0 0 9 264.36 796.92 Tm
(201)Tj
(9)Tj
/C2_0 1 Tf
2.28 0 Td
<14A414A414D618D50A7A>Tj
```
Therefore I adjusted test iss_1142.

After generating a svg export of Sample_Td-matrix.pdf I found a problem at the visitor-calls of #1252: One may get the wrong text matrix when an operator like Tm is executed together with not yet written text-output. I didn't want to mix that problem with the Td-bug therefore I created this PR first of all.