### PR TITLE
Use `process_time` instead of just `time` for measuring test performance.

### DIFF
--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -176,12 +176,17 @@ def test_readStringFromStream_performance():
     This test simulates reading an embedded base64 image of 256kb.
     It should be faster than a second, even on ancient machines.
     Runs < 100ms on a 2019 notebook. Takes 10 seconds prior to #1350.
+
+    `time.thread_time` is available in python >= 3.7. We are running tests in
+    parallel in CI, and we don't want the other tests to fail this test due to
+    total time. So simply skip it on lower python versions.
     """
-    stream = BytesIO(b"(" + b"".join([b"x"] * 1024 * 256) + b")")
-    start = time.process_time()
-    assert read_string_from_stream(stream)
-    end = time.process_time()
-    assert end - start < 2, test_readStringFromStream_performance.__doc__
+    if getattr(time, "thread_time"):
+        stream = BytesIO(b"(" + b"".join([b"x"] * 1024 * 256) + b")")
+        start = time.thread_time()
+        assert read_string_from_stream(stream)
+        end = time.thread_time()
+        assert end - start < 2, test_readStringFromStream_performance.__doc__
 
 
 def test_NameObject(caplog):

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -181,7 +181,7 @@ def test_readStringFromStream_performance():
     parallel in CI, and we don't want the other tests to fail this test due to
     total time. So simply skip it on lower python versions.
     """
-    if getattr(time, "thread_time"):
+    if getattr(time, "thread_time", None):
         stream = BytesIO(b"(" + b"".join([b"x"] * 1024 * 256) + b")")
         start = time.thread_time()
         assert read_string_from_stream(stream)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -178,9 +178,9 @@ def test_readStringFromStream_performance():
     Runs < 100ms on a 2019 notebook. Takes 10 seconds prior to #1350.
     """
     stream = BytesIO(b"(" + b"".join([b"x"] * 1024 * 256) + b")")
-    start = time.time()
+    start = time.process_time()
     assert read_string_from_stream(stream)
-    end = time.time()
+    end = time.process_time()
     assert end - start < 2, test_readStringFromStream_performance.__doc__
 
 


### PR DESCRIPTION
I hope this removes a handful of random test fails on supposedly busy cloud runners. At least it is worth a try. 

`thread_time` https://docs.python.org/3/library/time.html#time.thread_time could help with parallel test runs, too, but that only is available since Python 3.7.

`process_time` is available since Python 3.3.

This PR is a follow up to 
- https://github.com/py-pdf/PyPDF2/pull/1404 
- https://github.com/py-pdf/PyPDF2/pull/1355

