### PR TITLE
TST: Use Ubuntu 20.04 for running CI test suite

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   tests:
     name: pytest on ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
Closes #1451 

This sets the test suite to use `ubuntu-20.04` as opposed to `ubuntu-latest` as the latter switched over in the last day or so to using `ubuntu-22.04` and that broke testing Python 3.6. Ubuntu 20.04 has maintenance fixes for another ~2.5 years, and is supported critically for another 5 years after that, so the OS itself should be fine until we drop support for Python 3.6, and could then switch to `ubuntu-22.04`. It's also possible that the latter image will become compatible with Python 3.6 as well, but who knows.