### PR TITLE
MAINT: Changed conf.py to make myst parse all links as simple hyperlinks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ author = "Mathieu Fenniak"
 
 
 # -- General configuration ---------------------------------------------------
-
+myst_all_links_external = True
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.


### PR DESCRIPTION
Added `myst_all_links_external = True` to conf.py's global configuration as described [here](https://myst-parser.readthedocs.io/en/latest/configuration.html)

Closes #1492